### PR TITLE
Skip integration tests without services

### DIFF
--- a/real_components_test.py
+++ b/real_components_test.py
@@ -4,7 +4,18 @@ Focused testing for Real Components Implementation
 Tests the newly implemented real components as specified in the review request
 """
 
-import requests
+import os
+
+import pytest
+
+requests = pytest.importorskip(
+    "requests", reason="HTTP integration tests require the optional 'requests' dependency"
+)
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_FIXOPS_INTEGRATION_TESTS") != "1",
+    reason="FixOps real component integration tests require running services",
+)
 import json
 import sys
 import os

--- a/test_frontend.py
+++ b/test_frontend.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
-"""
-Simple test script to verify frontend is accessible and working
-"""
-import requests
-import time
+"""Simple test script to verify frontend is accessible and working."""
+
+import os
+
+import pytest
+
+requests = pytest.importorskip(
+    "requests", reason="HTTP integration tests require the optional 'requests' dependency"
+)
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_FIXOPS_INTEGRATION_TESTS") != "1",
+    reason="FixOps frontend integration tests require running services",
+)
 
 def test_frontend():
     print("=== TESTING FRONTEND ACCESSIBILITY ===")


### PR DESCRIPTION
## Summary
- skip the backend, real component, and frontend integration suites when services are not running
- use `pytest.importorskip` so the optional `requests` dependency is only required for integration runs
- allow the backend API test helper to accept multiple expected status codes when evaluating responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de7aa1b74883298a0b1232b51ad7a9