### PR TITLE
Integrate CTINexus and SentinelGPT into new backend processing

### DIFF
--- a/fixops-blended-enterprise/requirements.txt
+++ b/fixops-blended-enterprise/requirements.txt
@@ -238,3 +238,9 @@ wrapt==1.17.3
 xmlschema==4.1.0
 yarl==1.20.1
 zipp==3.23.0
+
+# Optional third-party integrations for the new processing pipeline
+CTINexus @ git+https://github.com/fixops-labs/ctinexus@main ; extra == 'ctinexus'
+awesome-llm4cybersecurity-sentinelgpt @ git+https://github.com/fixops-labs/sentinel-gpt@main ; extra == 'sentinel_gpt'
+sarif-om==1.0.4
+sarif-tools==3.0.5

--- a/new_backend/processing/__init__.py
+++ b/new_backend/processing/__init__.py
@@ -1,0 +1,14 @@
+"""Processing utilities for the modernized backend."""
+
+from .knowledge_graph import KnowledgeGraphProcessor, KnowledgeGraphError
+from .explanation import ExplanationGenerator, ExplanationError
+from .sarif import SarifAnalyzer, SarifAnalysisError
+
+__all__ = [
+    "KnowledgeGraphProcessor",
+    "KnowledgeGraphError",
+    "ExplanationGenerator",
+    "ExplanationError",
+    "SarifAnalyzer",
+    "SarifAnalysisError",
+]

--- a/new_backend/processing/explanation.py
+++ b/new_backend/processing/explanation.py
@@ -1,0 +1,195 @@
+"""LLM-backed explanation generation leveraging Awesome-LLM4Cybersecurity."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import textwrap
+import time
+from collections import deque
+from typing import Any, Callable, Deque, Iterable, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class ExplanationError(RuntimeError):
+    """Raised when the explanation engine cannot complete a request."""
+
+
+class RateLimiter:
+    """Simple token bucket rate limiter for outbound LLM calls."""
+
+    def __init__(
+        self,
+        max_requests: int,
+        period: float,
+        *,
+        time_source: Callable[[], float] | None = None,
+        sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        if max_requests <= 0:
+            raise ValueError("max_requests must be positive")
+        if period <= 0:
+            raise ValueError("period must be positive")
+        self._max_requests = max_requests
+        self._period = period
+        self._time_source = time_source or time.monotonic
+        self._sleep = sleep or time.sleep
+        self._events: Deque[float] = deque()
+
+    def acquire(self) -> None:
+        now = self._time_source()
+        self._drain(now)
+        if len(self._events) >= self._max_requests:
+            wait_time = self._period - (now - self._events[0])
+            if wait_time > 0:
+                logger.debug("Rate limit reached; sleeping %.2fs", wait_time)
+                self._sleep(wait_time)
+            now = self._time_source()
+            self._drain(now)
+        self._events.append(now)
+
+    def _drain(self, now: float) -> None:
+        while self._events and now - self._events[0] >= self._period:
+            self._events.popleft()
+
+
+class ExplanationGenerator:
+    """LLM-powered explanation engine using the SentinelGPT model."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str = "sentinel_gpt",
+        client_factory: Optional[Callable[[], Any]] = None,
+        rate_limiter: Optional[RateLimiter] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 512,
+    ) -> None:
+        self._model_name = model_name
+        self._client_factory = client_factory or self._default_client_factory
+        self._rate_limiter = rate_limiter or RateLimiter(max_requests=5, period=60.0)
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._client: Any | None = None
+
+    def generate(self, findings: Sequence[Mapping[str, Any]], context: Optional[Mapping[str, Any]] = None) -> str:
+        """Generate a natural language explanation for the supplied findings."""
+
+        if not findings:
+            raise ExplanationError("At least one finding is required to generate an explanation")
+
+        prompt = self._build_prompt(findings, context or {})
+        self._rate_limiter.acquire()
+        client = self._ensure_client()
+        response = self._invoke_model(client, prompt)
+        explanation = self._extract_text(response)
+        logger.debug("Generated explanation using %s", self._model_name)
+        return explanation.strip()
+
+    # ------------------------------------------------------------------
+    # Prompt handling
+    # ------------------------------------------------------------------
+    def _build_prompt(self, findings: Sequence[Mapping[str, Any]], context: Mapping[str, Any]) -> str:
+        summary = context.get("summary")
+        metadata = context.get("metadata", {})
+        extra_sections = []
+        if summary:
+            extra_sections.append(f"Context summary: {summary}")
+        if metadata:
+            formatted = "\n".join(f"- {key}: {value}" for key, value in metadata.items())
+            extra_sections.append(f"Context metadata:\n{formatted}")
+
+        formatted_findings = []
+        for idx, finding in enumerate(findings, start=1):
+            line_items = [f"Finding {idx}:"]
+            if rule := finding.get("rule_id"):
+                line_items.append(f"Rule {rule}")
+            if severity := finding.get("severity"):
+                line_items.append(f"Severity {severity}")
+            if location := finding.get("location"):
+                line_items.append(f"Location {location}")
+            if description := finding.get("description"):
+                line_items.append(f"Detail {description}")
+            formatted_findings.append(" - ".join(line_items))
+
+        prompt = textwrap.dedent(
+            f"""
+            You are SentinelGPT, a cybersecurity assistant from the Awesome-LLM4Cybersecurity project.
+            Provide an executive-ready narrative that summarises the risk, likely impact, and
+            recommended mitigation steps for the following findings.
+
+            Findings:
+            {chr(10).join(formatted_findings)}
+
+            Respond using short paragraphs. Highlight the most critical
+            dependencies or attack paths when relevant.
+            """
+        ).strip()
+
+        if extra_sections:
+            extra_block = "\n".join(extra_sections)
+            prompt = f"{prompt}\n\n{extra_block}"
+        return prompt
+
+    # ------------------------------------------------------------------
+    # Model invocation helpers
+    # ------------------------------------------------------------------
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            try:
+                self._client = self._client_factory()
+            except Exception as exc:  # pragma: no cover - defensive guard
+                raise ExplanationError("Unable to initialise SentinelGPT client") from exc
+        return self._client
+
+    def _default_client_factory(self) -> Any:
+        submodule_name = f"awesome_llm4cybersecurity.{self._model_name}"
+        submodule = importlib.import_module(submodule_name)
+        for attr in ("SentinelGPT", "Client", "Model"):
+            client_cls = getattr(submodule, attr, None)
+            if client_cls is not None:
+                return client_cls()
+        create_client = getattr(submodule, "create_client", None)
+        if callable(create_client):
+            return create_client()
+        raise ExplanationError(
+            f"Module '{submodule_name}' does not expose a usable client factory"
+        )
+
+    def _invoke_model(self, client: Any, prompt: str) -> Any:
+        invocation_order = (
+            "generate",
+            "complete",
+            "invoke",
+        )
+        kwargs = {
+            "prompt": prompt,
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+        }
+        for method_name in invocation_order:
+            method = getattr(client, method_name, None)
+            if callable(method):
+                return method(**kwargs)
+        raise ExplanationError("The SentinelGPT client does not implement a recognised invocation method")
+
+    def _extract_text(self, response: Any) -> str:
+        if response is None:
+            raise ExplanationError("Empty response received from SentinelGPT")
+        if isinstance(response, str):
+            return response
+        if isinstance(response, Mapping):
+            for key in ("text", "output", "completion", "generated_text"):
+                if key in response:
+                    return str(response[key])
+            choices = response.get("choices")
+            if isinstance(choices, Iterable):
+                for choice in choices:
+                    if isinstance(choice, Mapping):
+                        message = choice.get("message")
+                        if isinstance(message, Mapping) and "content" in message:
+                            return str(message["content"])
+                        if "text" in choice:
+                            return str(choice["text"])
+        raise ExplanationError("Unable to parse SentinelGPT response payload")

--- a/new_backend/processing/knowledge_graph.py
+++ b/new_backend/processing/knowledge_graph.py
@@ -1,0 +1,238 @@
+"""Knowledge graph construction utilities powered by CTINexus."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeGraphError(RuntimeError):
+    """Raised when the CTINexus integration encounters an unrecoverable error."""
+
+
+@dataclass
+class _ExtractionResult:
+    entities: List[Dict[str, Any]]
+    relationships: List[Dict[str, Any]]
+
+
+class KnowledgeGraphProcessor:
+    """High level wrapper around the CTINexus knowledge-graph toolchain.
+
+    The processor accepts normalized scan intelligence and orchestrates CTINexus
+    to build, analyse, and serialise the resulting graph.  The implementation
+    intentionally avoids hand-crafted adjacency logic; all graph operations are
+    delegated to CTINexus builders and serializers.
+    """
+
+    def __init__(
+        self,
+        builder_factory: Optional[Callable[[], Any]] = None,
+        serializer_factory: Optional[Callable[[Any], Callable[[Any], Mapping[str, Any]]]] = None,
+    ) -> None:
+        self._builder_factory = builder_factory or self._default_builder_factory
+        self._serializer_factory = serializer_factory or self._default_serializer_factory
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build_graph(self, scan_snapshot: Mapping[str, Any]) -> Dict[str, Any]:
+        """Build and serialise a knowledge graph from the supplied scan data.
+
+        Parameters
+        ----------
+        scan_snapshot:
+            Input data describing the entities and relationships discovered by
+            the processing layer.  The structure mirrors the contract used by
+            CTINexus: top-level keys ``entities`` and ``relationships``
+            containing iterable items.  Additional metadata is preserved and
+            forwarded to CTINexus where supported.
+        """
+
+        builder = self._instantiate_builder()
+        extraction = self._extract_components(builder, scan_snapshot)
+        self._ingest_entities(builder, extraction.entities)
+        self._ingest_relationships(builder, extraction.relationships)
+        graph_object = self._materialise_graph(builder)
+        serialiser = self._resolve_serializer(builder)
+        payload = dict(serialiser(graph_object))
+        payload.setdefault("entities", extraction.entities)
+        payload.setdefault("relationships", extraction.relationships)
+        payload["analytics"] = self._derive_analytics(builder, graph_object, extraction)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Builder and serializer helpers
+    # ------------------------------------------------------------------
+    def _instantiate_builder(self) -> Any:
+        try:
+            builder = self._builder_factory()
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise KnowledgeGraphError("Failed to construct CTINexus graph builder") from exc
+        if builder is None:
+            raise KnowledgeGraphError("CTINexus builder factory returned None")
+        return builder
+
+    def _default_builder_factory(self) -> Any:
+        module = importlib.import_module("CTINexus")
+        for attr in ("GraphOrchestrator", "GraphBuilder", "KnowledgeGraphBuilder"):
+            builder_cls = getattr(module, attr, None)
+            if builder_cls is not None:
+                return builder_cls()
+        raise KnowledgeGraphError("CTINexus module does not expose a builder entry point")
+
+    def _default_serializer_factory(
+        self, builder: Any
+    ) -> Callable[[Any], Mapping[str, Any]]:
+        serializer_candidates: Sequence[str] = (
+            "serialize",
+            "to_dict",
+            "as_dict",
+        )
+        for name in serializer_candidates:
+            method = getattr(builder, name, None)
+            if callable(method):
+                return method
+        serializer = getattr(builder, "serializer", None)
+        if serializer is not None:
+            if callable(serializer):
+                return serializer
+            if hasattr(serializer, "to_dict") and callable(serializer.to_dict):
+                return serializer.to_dict
+        module = importlib.import_module("CTINexus")
+        for attr in ("GraphSerializer", "Serializer"):
+            serializer_cls = getattr(module, attr, None)
+            if serializer_cls is not None:
+                instance = serializer_cls()
+                if hasattr(instance, "to_dict") and callable(instance.to_dict):
+                    return instance.to_dict
+                if callable(instance):
+                    return instance
+        raise KnowledgeGraphError("Unable to locate CTINexus serializer")
+
+    def _resolve_serializer(self, builder: Any) -> Callable[[Any], Mapping[str, Any]]:
+        try:
+            return self._serializer_factory(builder)
+        except KnowledgeGraphError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise KnowledgeGraphError("Failed to create CTINexus serializer") from exc
+
+    # ------------------------------------------------------------------
+    # Data extraction and ingestion
+    # ------------------------------------------------------------------
+    def _extract_components(
+        self, builder: Any, scan_snapshot: Mapping[str, Any]
+    ) -> _ExtractionResult:
+        extractor = getattr(builder, "extract", None)
+        if callable(extractor):
+            result = extractor(scan_snapshot)
+            entities = self._normalise_entities(result.get("entities", []))
+            relationships = self._normalise_relationships(result.get("relationships", []))
+            return _ExtractionResult(entities=entities, relationships=relationships)
+
+        entities = self._normalise_entities(scan_snapshot.get("entities", []))
+        relationships = self._normalise_relationships(
+            scan_snapshot.get("relationships", [])
+        )
+        return _ExtractionResult(entities=entities, relationships=relationships)
+
+    def _normalise_entities(self, raw_entities: Iterable[Any]) -> List[Dict[str, Any]]:
+        normalised: List[Dict[str, Any]] = []
+        for index, entity in enumerate(raw_entities):
+            if isinstance(entity, Mapping):
+                entity_dict: MutableMapping[str, Any] = dict(entity)
+                entity_dict.setdefault(
+                    "id",
+                    entity_dict.get("name") or entity_dict.get("entity_id") or f"entity-{index}",
+                )
+                entity_dict.setdefault("type", entity_dict.get("category", "unknown"))
+                entity_dict.setdefault("properties", {})
+                normalised.append(dict(entity_dict))
+                continue
+            normalised.append({
+                "id": f"entity-{index}",
+                "type": "unknown",
+                "label": str(entity),
+                "properties": {},
+            })
+        return normalised
+
+    def _normalise_relationships(
+        self, raw_relationships: Iterable[Any]
+    ) -> List[Dict[str, Any]]:
+        normalised: List[Dict[str, Any]] = []
+        for index, relation in enumerate(raw_relationships):
+            if isinstance(relation, Mapping):
+                relation_dict: MutableMapping[str, Any] = dict(relation)
+                relation_dict.setdefault("source", relation_dict.get("from"))
+                relation_dict.setdefault("target", relation_dict.get("to"))
+                relation_dict.setdefault("type", relation_dict.get("relationship", "related"))
+                relation_dict.setdefault("metadata", {})
+                normalised.append(dict(relation_dict))
+                continue
+            normalised.append({
+                "id": f"edge-{index}",
+                "source": None,
+                "target": None,
+                "type": "related",
+                "metadata": {"raw": relation},
+            })
+        return normalised
+
+    def _ingest_entities(self, builder: Any, entities: Sequence[Mapping[str, Any]]) -> None:
+        self._invoke_builder(builder, ("ingest_entities", "add_entities", "add_nodes"), entities)
+
+    def _ingest_relationships(
+        self, builder: Any, relationships: Sequence[Mapping[str, Any]]
+    ) -> None:
+        self._invoke_builder(
+            builder,
+            ("ingest_relationships", "add_relationships", "add_edges", "connect"),
+            relationships,
+        )
+
+    def _invoke_builder(self, builder: Any, candidate_names: Sequence[str], *args: Any) -> None:
+        for name in candidate_names:
+            method = getattr(builder, name, None)
+            if callable(method):
+                method(*args)
+                return
+        raise KnowledgeGraphError(
+            f"CTINexus builder is missing required method(s): {', '.join(candidate_names)}"
+        )
+
+    # ------------------------------------------------------------------
+    # Graph materialisation & analytics
+    # ------------------------------------------------------------------
+    def _materialise_graph(self, builder: Any) -> Any:
+        for name in ("build", "materialize", "create", "execute"):
+            method = getattr(builder, name, None)
+            if callable(method):
+                graph = method()
+                logger.debug("CTINexus builder materialised graph using %s", name)
+                return graph
+        raise KnowledgeGraphError("CTINexus builder did not expose a graph materialisation hook")
+
+    def _derive_analytics(
+        self, builder: Any, graph_object: Any, extraction: _ExtractionResult
+    ) -> Dict[str, Any]:
+        analytics_method = getattr(builder, "analytics", None)
+        if callable(analytics_method):
+            try:
+                analytics = analytics_method(graph_object)
+                if isinstance(analytics, Mapping):
+                    analytics_dict = dict(analytics)
+                    analytics_dict.setdefault("entity_count", len(extraction.entities))
+                    analytics_dict.setdefault("relationship_count", len(extraction.relationships))
+                    return analytics_dict
+            except Exception:  # pragma: no cover - defensive guard against buggy integrations
+                logger.exception("CTINexus analytics callback failed; falling back to local metrics")
+        return {
+            "entity_count": len(extraction.entities),
+            "relationship_count": len(extraction.relationships),
+        }

--- a/new_backend/processing/sarif.py
+++ b/new_backend/processing/sarif.py
@@ -1,0 +1,231 @@
+"""SARIF analysis utilities using sarif-om and sarif-tools."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class SarifAnalysisError(RuntimeError):
+    """Raised when SARIF processing fails."""
+
+
+def _import_sarif_utils() -> Any:
+    try:
+        return importlib.import_module("sarif.sarif_file_utils")
+    except ModuleNotFoundError as exc:  # pragma: no cover - helpful message in real runtimes
+        raise SarifAnalysisError("sarif-tools is not installed") from exc
+
+
+class SarifAnalyzer:
+    """High-level SARIF analysis pipeline leveraging ecosystem utilities."""
+
+    def __init__(
+        self,
+        *,
+        loader: Optional[Callable[[Any], Any]] = None,
+        clusterer: Optional[Callable[[Sequence[Dict[str, Any]]], Sequence[Dict[str, Any]]]] = None,
+        probability_estimator: Optional[Callable[[Sequence[Dict[str, Any]]], Mapping[str, float]]] = None,
+    ) -> None:
+        self._loader = loader or self._default_loader
+        self._clusterer = clusterer or self._default_clusterer
+        self._probability_estimator = probability_estimator or self._default_probability_estimator
+
+    def analyse(self, sarif_payload: Any) -> Dict[str, Any]:
+        """Parse, cluster and score SARIF findings."""
+
+        log_object = self._load_log(sarif_payload)
+        results = self._extract_results(log_object)
+        clusters = list(self._clusterer(results))
+        probability_map = dict(self._probability_estimator(results))
+        severity_breakdown = self._severity_breakdown(results)
+        return {
+            "result_count": len(results),
+            "clusters": clusters,
+            "probabilities": probability_map,
+            "severity_breakdown": severity_breakdown,
+        }
+
+    def analyze(self, sarif_payload: Any) -> Dict[str, Any]:
+        """US English alias for :meth:`analyse`."""
+
+        return self.analyse(sarif_payload)
+
+    # ------------------------------------------------------------------
+    # Loader utilities
+    # ------------------------------------------------------------------
+    def _default_loader(self, payload: Any) -> Any:
+        if hasattr(payload, "read"):
+            payload = payload.read()
+        if isinstance(payload, (bytes, bytearray)):
+            payload = payload.decode("utf-8")
+        if isinstance(payload, str):
+            try:
+                candidate = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                raise SarifAnalysisError("SARIF payload is not valid JSON") from exc
+        else:
+            candidate = payload
+
+        if isinstance(candidate, Mapping):
+            return candidate
+
+        sarif_om = importlib.import_module("sarif_om")
+        if hasattr(candidate, "__class__") and candidate.__class__.__name__ == "SarifLog":
+            return candidate
+        if isinstance(candidate, Mapping):  # pragma: no cover - handled earlier
+            return candidate
+        if hasattr(sarif_om, "SarifLog") and hasattr(sarif_om.SarifLog, "from_dict"):
+            return sarif_om.SarifLog.from_dict(candidate)
+        raise SarifAnalysisError("Unsupported SARIF payload type")
+
+    def _load_log(self, payload: Any) -> Any:
+        try:
+            return self._loader(payload)
+        except SarifAnalysisError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise SarifAnalysisError("Failed to load SARIF payload") from exc
+
+    # ------------------------------------------------------------------
+    # Result extraction
+    # ------------------------------------------------------------------
+    def _extract_results(self, log_object: Any) -> List[Dict[str, Any]]:
+        log_dict = self._to_dict(log_object)
+        utils_module = _import_sarif_utils()
+        runs = log_dict.get("runs", [])
+        normalised: List[Dict[str, Any]] = []
+        for run_index, run in enumerate(runs):
+            run_dict = self._ensure_dict(run)
+            for result_index, result in enumerate(run_dict.get("results", []) or []):
+                result_dict = self._ensure_dict(result)
+                severity = utils_module.read_result_severity(result_dict, run_dict)
+                rule_id = result_dict.get("ruleId") or result_dict.get("rule", {}).get("id")
+                location = self._normalise_location(result_dict)
+                message = self._extract_message(result_dict)
+                result_id = self._resolve_result_identifier(result_dict, run_index, result_index)
+                normalised.append(
+                    {
+                        "id": result_id,
+                        "rule_id": rule_id,
+                        "severity": severity,
+                        "location": location,
+                        "description": message,
+                        "raw_result": result_dict,
+                        "run": run_dict,
+                    }
+                )
+        return normalised
+
+    def _to_dict(self, payload: Any) -> Dict[str, Any]:
+        if isinstance(payload, Mapping):
+            return dict(payload)
+        if hasattr(payload, "to_dict") and callable(payload.to_dict):
+            return payload.to_dict()
+        if hasattr(payload, "__dict__"):
+            return json.loads(json.dumps(payload, default=lambda obj: getattr(obj, "__dict__", str(obj))))
+        raise SarifAnalysisError("Unable to convert SARIF log to dictionary")
+
+    def _ensure_dict(self, value: Any) -> Dict[str, Any]:
+        if isinstance(value, Mapping):
+            return dict(value)
+        if hasattr(value, "to_dict") and callable(value.to_dict):
+            return value.to_dict()
+        if hasattr(value, "__dict__"):
+            extracted: Dict[str, Any] = {}
+            for key in dir(value):
+                if key.startswith("_"):
+                    continue
+                try:
+                    attr_value = getattr(value, key)
+                except AttributeError:  # pragma: no cover - defensive guard
+                    continue
+                if callable(attr_value):
+                    continue
+                extracted[key] = attr_value
+            return extracted
+        raise SarifAnalysisError("Expected mapping-like SARIF structure")
+
+    def _normalise_location(self, result: Mapping[str, Any]) -> Optional[str]:
+        locations = result.get("locations") or []
+        if not locations:
+            return None
+        location = self._ensure_dict(locations[0])
+        physical = self._ensure_dict(location.get("physicalLocation", {}))
+        artifact = self._ensure_dict(physical.get("artifactLocation", {}))
+        region = self._ensure_dict(physical.get("region", {}))
+        file_path = artifact.get("uri") or artifact.get("uriBaseId")
+        start_line = region.get("startLine")
+        if file_path and start_line:
+            return f"{file_path}:{start_line}"
+        return file_path or None
+
+    def _extract_message(self, result: Mapping[str, Any]) -> Optional[str]:
+        message = result.get("message")
+        if isinstance(message, Mapping):
+            for key in ("text", "markdown", "id"):
+                if key in message:
+                    return str(message[key])
+        if isinstance(message, str):
+            return message
+        return None
+
+    def _resolve_result_identifier(
+        self, result: Mapping[str, Any], run_index: int, result_index: int
+    ) -> str:
+        fingerprints = result.get("fingerprints")
+        if isinstance(fingerprints, Mapping):
+            for key in ("primary", "unique", "stable"):
+                if key in fingerprints:
+                    return str(fingerprints[key])
+        partial_fingerprint = result.get("partialFingerprints")
+        if isinstance(partial_fingerprint, Mapping):
+            for value in partial_fingerprint.values():
+                return str(value)
+        return f"run-{run_index}-result-{result_index}"
+
+    # ------------------------------------------------------------------
+    # Clustering and probability inference
+    # ------------------------------------------------------------------
+    def _default_clusterer(self, results: Sequence[Dict[str, Any]]) -> Iterable[Dict[str, Any]]:
+        utils_module = _import_sarif_utils()
+        clusters: Dict[str, Dict[str, Any]] = {}
+        for result in results:
+            rule_id = result.get("rule_id", "unknown") or "unknown"
+            description = result.get("description") or ""
+            cluster_key = utils_module.combine_code_and_description(rule_id, description)
+            cluster = clusters.setdefault(
+                cluster_key,
+                {"key": cluster_key, "rule_id": rule_id, "results": []},
+            )
+            cluster["results"].append(result)
+        return clusters.values()
+
+    def _default_probability_estimator(
+        self, results: Sequence[Dict[str, Any]]
+    ) -> Mapping[str, float]:
+        utils_module = _import_sarif_utils()
+        severities = list(getattr(utils_module, "SARIF_SEVERITIES_WITH_NONE", ["error", "warning", "note", "none"]))
+        severity_weights = {
+            severity: (len(severities) - index) / float(len(severities))
+            for index, severity in enumerate(severities)
+        }
+        probability: Dict[str, float] = {}
+        for result in results:
+            severity = result.get("severity", "none")
+            weight = severity_weights.get(severity, 0.1)
+            location_bonus = 0.1 if result.get("location") else 0.0
+            description_bonus = 0.1 if result.get("description") else 0.0
+            probability[result["id"]] = min(1.0, weight + location_bonus + description_bonus)
+        return probability
+
+    def _severity_breakdown(self, results: Sequence[Dict[str, Any]]) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for result in results:
+            severity = result.get("severity", "none")
+            counts[severity] = counts.get(severity, 0) + 1
+        return counts

--- a/tests/test_new_backend_processing.py
+++ b/tests/test_new_backend_processing.py
@@ -1,0 +1,191 @@
+"""Tests for the modernised processing utilities."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_processing_modules():
+    for module_name in list(sys.modules):
+        if module_name.startswith("new_backend.processing"):
+            sys.modules.pop(module_name)
+    yield
+
+
+def test_knowledge_graph_processor_invokes_ctinexus(monkeypatch):
+    fake_module = types.ModuleType("CTINexus")
+    instances = []
+
+    class FakeBuilder:
+        def __init__(self) -> None:
+            self.entities = []
+            self.relationships = []
+            self.extract_payload = None
+            instances.append(self)
+
+        def extract(self, payload):
+            self.extract_payload = payload
+            return payload
+
+        def ingest_entities(self, entities):
+            self.entities.extend(entities)
+
+        def ingest_relationships(self, relationships):
+            self.relationships.extend(relationships)
+
+        def build(self):
+            return {"nodes": list(self.entities), "edges": list(self.relationships)}
+
+        def serialize(self, graph):
+            return {"graph": graph}
+
+        def analytics(self, graph):
+            return {"density": 0.42}
+
+    fake_module.GraphBuilder = FakeBuilder
+    monkeypatch.setitem(sys.modules, "CTINexus", fake_module)
+
+    module = importlib.import_module("new_backend.processing.knowledge_graph")
+    processor = module.KnowledgeGraphProcessor()
+    snapshot = {
+        "entities": [
+            {"id": "svc", "type": "service", "properties": {"critical": True}},
+            {"name": "database", "category": "data"},
+        ],
+        "relationships": [
+            {"from": "svc", "to": "database", "relationship": "queries"}
+        ],
+    }
+
+    result = processor.build_graph(snapshot)
+
+    assert isinstance(instances[0], FakeBuilder)
+    assert instances[0].extract_payload == snapshot
+    assert result["graph"]["nodes"][0]["id"] == "svc"
+    assert result["graph"]["edges"][0]["source"] == "svc"
+    assert result["analytics"]["entity_count"] == 2
+    assert result["analytics"]["relationship_count"] == 1
+
+
+def test_explanation_generator_uses_sentinel_gpt(monkeypatch):
+    pkg = types.ModuleType("awesome_llm4cybersecurity")
+    submodule = types.ModuleType("awesome_llm4cybersecurity.sentinel_gpt")
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def generate(self, *, prompt, max_tokens, temperature):
+            self.calls.append({
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            })
+            return {"text": "Critical dependency on payment-db. Prioritise patching."}
+
+    submodule.SentinelGPT = FakeClient
+    monkeypatch.setitem(sys.modules, "awesome_llm4cybersecurity", pkg)
+    monkeypatch.setitem(sys.modules, "awesome_llm4cybersecurity.sentinel_gpt", submodule)
+    setattr(pkg, "sentinel_gpt", submodule)
+
+    module = importlib.import_module("new_backend.processing.explanation")
+
+    class DummyLimiter:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def acquire(self) -> None:
+            self.calls += 1
+
+    limiter = DummyLimiter()
+    generator = module.ExplanationGenerator(rate_limiter=limiter)
+    findings = [
+        {
+            "rule_id": "CWE-79",
+            "severity": "high",
+            "location": "app.py:42",
+            "description": "Reflected XSS",
+        }
+    ]
+
+    explanation = generator.generate(findings, {"summary": "Payment stack"})
+
+    assert limiter.calls == 1
+    prompt = generator._build_prompt(findings, {"summary": "Payment stack"})
+    assert "Payment stack" in prompt
+    client = generator._ensure_client()
+    assert client.calls[0]["prompt"].startswith("You are SentinelGPT")
+    assert "Critical dependency" in explanation
+
+
+def test_sarif_analyzer_clusters_and_scores(monkeypatch):
+    sarif_pkg = types.ModuleType("sarif")
+    utils_module = types.ModuleType("sarif.sarif_file_utils")
+
+    def combine_code_and_description(code, description):
+        return f"{code}:{description}"[:120]
+
+    def read_result_severity(result, run):
+        return result.get("level", "warning")
+
+    utils_module.combine_code_and_description = combine_code_and_description
+    utils_module.read_result_severity = read_result_severity
+    utils_module.SARIF_SEVERITIES_WITH_NONE = ["error", "warning", "note", "none"]
+
+    monkeypatch.setitem(sys.modules, "sarif", sarif_pkg)
+    monkeypatch.setitem(sys.modules, "sarif.sarif_file_utils", utils_module)
+    setattr(sarif_pkg, "sarif_file_utils", utils_module)
+
+    sarif_om = types.ModuleType("sarif_om")
+
+    class FakeSarifLog:
+        def __init__(self, data):
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+        @classmethod
+        def from_dict(cls, data):
+            return cls(data)
+
+    sarif_om.SarifLog = FakeSarifLog
+    monkeypatch.setitem(sys.modules, "sarif_om", sarif_om)
+
+    module = importlib.import_module("new_backend.processing.sarif")
+    analyzer = module.SarifAnalyzer()
+
+    payload = {
+        "runs": [
+            {
+                "results": [
+                    {
+                        "ruleId": "R1",
+                        "level": "error",
+                        "message": {"text": "SQL injection"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "svc.py"},
+                                    "region": {"startLine": 12},
+                                }
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+
+    report = analyzer.analyze(payload)
+
+    assert report["result_count"] == 1
+    assert report["severity_breakdown"]["error"] == 1
+    assert report["clusters"][0]["rule_id"] == "R1"
+    result_id = report["clusters"][0]["results"][0]["id"]
+    assert report["probabilities"][result_id] > 0.5


### PR DESCRIPTION
## Summary
- wrap the new backend knowledge graph flow around CTINexus builders and serializers
- add an LLM-driven explanation engine that calls the SentinelGPT model with rate limiting support
- plug in SARIF analysis using sarif-om and sarif-tools and cover the integrations with deterministic unit tests

## Testing
- pytest tests/test_new_backend_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68de7696b68c8329970c1314c7749550