### PR TITLE
Add context-aware risk scoring and compliance severity tracking

### DIFF
--- a/fixops-blended-enterprise/src/services/compliance_engine.py
+++ b/fixops-blended-enterprise/src/services/compliance_engine.py
@@ -1,0 +1,118 @@
+"""FixOps Compliance Engine - maps risk-adjusted findings to framework posture."""
+
+from typing import Any, Dict, List, Optional
+import structlog
+
+logger = structlog.get_logger()
+
+
+class ComplianceEngine:
+    """Evaluate compliance posture using FixOps risk tiers."""
+
+    _SEVERITY_ORDER = ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+    def __init__(self) -> None:
+        self.framework_thresholds: Dict[str, str] = {
+            "pci_dss": "HIGH",
+            "sox": "HIGH",
+            "hipaa": "HIGH",
+            "nist": "MEDIUM",
+            "gdpr": "MEDIUM",
+        }
+
+    def evaluate(
+        self,
+        frameworks: List[str],
+        findings: List[Dict[str, Any]],
+        business_context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Evaluate one or more frameworks returning a mapping of results."""
+
+        results: Dict[str, Any] = {}
+        for framework in frameworks:
+            results[framework] = self._evaluate_framework(framework, findings, business_context)
+        return results
+
+    def _evaluate_framework(
+        self,
+        framework: str,
+        findings: List[Dict[str, Any]],
+        business_context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Evaluate a single framework using FixOps severity tiers."""
+
+        normalized_findings: List[Dict[str, Any]] = []
+        highest_scanner = "LOW"
+        highest_fixops = "LOW"
+
+        for finding in findings:
+            scanner_severity = self._normalize_severity(
+                finding.get("scanner_severity") or finding.get("severity")
+            )
+            fixops_severity = self._normalize_severity(
+                finding.get("fixops_severity")
+                or finding.get("risk_tier")
+                or finding.get("severity")
+            )
+
+            highest_scanner = self._max_severity(highest_scanner, scanner_severity)
+            highest_fixops = self._max_severity(highest_fixops, fixops_severity)
+
+            normalized_findings.append(
+                {
+                    "id": finding.get("id")
+                    or finding.get("cve")
+                    or finding.get("rule_id")
+                    or finding.get("title"),
+                    "scanner_severity": scanner_severity,
+                    "fixops_severity": fixops_severity,
+                    "risk_adjustment": finding.get("risk_adjustment", 0),
+                    "risk_factors": finding.get("risk_factors", []),
+                }
+            )
+
+        threshold = self.framework_thresholds.get(framework.lower(), "HIGH")
+        status = self._determine_status(threshold, highest_fixops)
+
+        result = {
+            "framework": framework,
+            "status": status,
+            "threshold": threshold,
+            "highest_scanner_severity": highest_scanner,
+            "highest_fixops_severity": highest_fixops,
+            "findings": normalized_findings,
+        }
+
+        logger.info(
+            "Compliance framework evaluated",
+            framework=framework,
+            status=status,
+            highest_scanner=highest_scanner,
+            highest_fixops=highest_fixops,
+        )
+
+        return result
+
+    def _determine_status(self, threshold: str, highest_fixops: str) -> str:
+        threshold_index = self._SEVERITY_ORDER.index(threshold)
+        fixops_index = self._SEVERITY_ORDER.index(highest_fixops)
+
+        if fixops_index >= threshold_index:
+            return "non_compliant"
+        if fixops_index == threshold_index - 1:
+            return "needs_review"
+        return "compliant"
+
+    def _normalize_severity(self, severity: Optional[str]) -> str:
+        if not severity:
+            return "LOW"
+        value = str(severity).upper()
+        if value not in self._SEVERITY_ORDER:
+            return "LOW"
+        return value
+
+    def _max_severity(self, current: str, other: str) -> str:
+        return current if self._SEVERITY_ORDER.index(current) >= self._SEVERITY_ORDER.index(other) else other
+
+
+compliance_engine = ComplianceEngine()

--- a/fixops-blended-enterprise/src/services/risk_scorer.py
+++ b/fixops-blended-enterprise/src/services/risk_scorer.py
@@ -1,0 +1,138 @@
+"""Context-aware risk scoring utilities for FixOps."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class ContextualRiskScorer:
+    """Apply business context aware adjustments to scanner findings."""
+
+    _SEVERITY_ORDER = ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    _SENSITIVE_DATA_CLASSIFICATIONS = {
+        "pii",
+        "phi",
+        "pci",
+        "confidential",
+        "restricted",
+        "secret",
+        "financial",
+        "customer",
+        "internal_high",
+    }
+    _LOW_DATA_CLASSIFICATIONS = {"public", "test", "non_sensitive"}
+    _HIGH_IMPACT_TERMS = {"high", "critical", "mission_critical", "major"}
+    _LOW_IMPACT_TERMS = {"low", "minor", "internal", "limited"}
+    _FAST_DEPLOYMENT = {"continuous", "hourly", "daily"}
+    _SLOW_DEPLOYMENT = {"monthly", "quarterly", "annual", "annually", "rare", "ad-hoc"}
+
+    def apply(
+        self,
+        findings: List[Dict[str, Any]],
+        business_context: Optional[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Return findings with context-aware risk adjustments applied."""
+
+        if not findings:
+            return []
+
+        adjusted: List[Dict[str, Any]] = []
+        for finding in findings:
+            adjusted.append(self._adjust_finding(finding, business_context or {}))
+        return adjusted
+
+    def _adjust_finding(
+        self, finding: Dict[str, Any], business_context: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        original_severity = self._normalize_severity(
+            finding.get("scanner_severity") or finding.get("severity")
+        )
+
+        result = dict(finding)
+        result["scanner_severity"] = original_severity
+
+        if result.get("fixops_severity"):
+            result["fixops_severity"] = self._normalize_severity(result["fixops_severity"])
+            result.setdefault("risk_tier", result["fixops_severity"])
+            delta = self._severity_index(result["fixops_severity"]) - self._severity_index(
+                original_severity
+            )
+            result.setdefault("risk_adjustment", delta)
+            return result
+
+        adjustment, factors = self._calculate_adjustment(business_context)
+        base_index = self._severity_index(original_severity)
+        adjusted_index = max(0, min(len(self._SEVERITY_ORDER) - 1, base_index + adjustment))
+        fixops_severity = self._SEVERITY_ORDER[adjusted_index]
+
+        result["fixops_severity"] = fixops_severity
+        result["risk_adjustment"] = adjusted_index - base_index
+        if factors:
+            result["risk_factors"] = factors
+        result.setdefault("risk_tier", fixops_severity)
+
+        return result
+
+    def _calculate_adjustment(
+        self, business_context: Dict[str, Any]
+    ) -> Tuple[int, List[str]]:
+        adjustment = 0
+        factors: List[str] = []
+
+        customer_impact = (
+            business_context.get("customer_impact")
+            or business_context.get("business_criticality")
+            or business_context.get("criticality")
+            or business_context.get("business_impact")
+        )
+        if isinstance(customer_impact, str):
+            impact_value = customer_impact.lower()
+            if impact_value in self._HIGH_IMPACT_TERMS:
+                adjustment += 1
+                factors.append("high_customer_impact")
+            elif impact_value in self._LOW_IMPACT_TERMS:
+                adjustment -= 1
+                factors.append("low_customer_impact")
+
+        data_classification = business_context.get("data_classification")
+        if data_classification:
+            if isinstance(data_classification, str):
+                data_values = {data_classification.lower()}
+            else:
+                data_values = {str(v).lower() for v in data_classification if v}
+
+            if data_values & self._SENSITIVE_DATA_CLASSIFICATIONS:
+                adjustment += 1
+                factors.append("sensitive_data")
+            elif data_values and data_values <= self._LOW_DATA_CLASSIFICATIONS:
+                adjustment -= 1
+                factors.append("non_sensitive_data")
+
+        deployment_frequency = business_context.get("deployment_frequency")
+        if isinstance(deployment_frequency, str):
+            frequency_value = deployment_frequency.lower()
+            if frequency_value in self._FAST_DEPLOYMENT:
+                adjustment += 1
+                factors.append("rapid_deployment")
+            elif frequency_value in self._SLOW_DEPLOYMENT:
+                adjustment -= 1
+                factors.append("infrequent_deployment")
+
+        if adjustment > 1:
+            adjustment = 1
+        elif adjustment < -1:
+            adjustment = -1
+
+        return adjustment, factors
+
+    def _normalize_severity(self, severity: Optional[str]) -> str:
+        if not severity:
+            return "MEDIUM"
+        severity_upper = str(severity).upper()
+        if severity_upper not in self._SEVERITY_ORDER:
+            return "MEDIUM"
+        return severity_upper
+
+    def _severity_index(self, severity: str) -> int:
+        try:
+            return self._SEVERITY_ORDER.index(severity)
+        except ValueError:
+            return 1

--- a/scripts/run_real_cve_playbook.py
+++ b/scripts/run_real_cve_playbook.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Run a FixOps CVE playbook and highlight severity reclassification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from rich.console import Console
+from rich.table import Table
+
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT / "fixops-blended-enterprise") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "fixops-blended-enterprise"))
+
+from src.services.risk_scorer import ContextualRiskScorer  # noqa: E402
+from src.services.compliance_engine import ComplianceEngine  # noqa: E402
+
+
+DEFAULT_CONTEXT = {
+    "service_name": "payment-service",
+    "environment": "production",
+    "business_context": {
+        "customer_impact": "critical",
+        "data_classification": ["pii", "financial"],
+        "deployment_frequency": "continuous",
+    },
+    "security_findings": [
+        {
+            "id": "CVE-2024-12345",
+            "title": "OpenSSL buffer overflow",
+            "severity": "medium",
+            "cve": "CVE-2024-12345",
+        },
+        {
+            "id": "CVE-2023-9876",
+            "title": "Old ORM SQL injection",
+            "severity": "critical",
+            "cve": "CVE-2023-9876",
+        },
+    ],
+    "compliance_requirements": ["pci_dss", "sox"],
+}
+
+
+def load_context(path: Path | None) -> Dict[str, Any]:
+    if not path:
+        return DEFAULT_CONTEXT
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def build_table(findings: List[Dict[str, Any]]) -> Table:
+    table = Table(title="FixOps Severity Reclassification", expand=True)
+    table.add_column("Finding", style="cyan", overflow="fold")
+    table.add_column("Scanner Severity", style="yellow")
+    table.add_column("FixOps Severity", style="magenta")
+    table.add_column("Risk Factors", style="green")
+
+    for finding in findings:
+        name = (
+            finding.get("id")
+            or finding.get("title")
+            or finding.get("cve")
+            or finding.get("rule_id")
+            or "Unknown"
+        )
+        risk_factors = ", ".join(finding.get("risk_factors", [])) or "-"
+        table.add_row(
+            name,
+            finding.get("scanner_severity", finding.get("severity", "UNKNOWN")),
+            finding.get("fixops_severity", finding.get("risk_tier", "UNKNOWN")),
+            risk_factors,
+        )
+
+    return table
+
+
+def print_compliance_results(console: Console, context: Dict[str, Any], findings: List[Dict[str, Any]]) -> None:
+    engine = ComplianceEngine()
+    frameworks = context.get("compliance_requirements", [])
+    if not frameworks:
+        return
+
+    results = [engine._evaluate_framework(framework, findings, context.get("business_context")) for framework in frameworks]
+    for result in results:
+        console.print(
+            f"[bold]{result['framework'].upper()}[/bold] status: {result['status']} "
+            f"(scanner {result['highest_scanner_severity']} → FixOps {result['highest_fixops_severity']})"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--context",
+        type=Path,
+        help="Path to a JSON payload with business_context and security_findings",
+    )
+    args = parser.parse_args()
+
+    context = load_context(args.context)
+    business_context = context.get("business_context", {})
+    findings = context.get("security_findings", [])
+
+    scorer = ContextualRiskScorer()
+    adjusted_findings = scorer.apply(findings, business_context)
+
+    console = Console()
+    console.print("[bold underline]FixOps Real CVE Playbook[/bold underline]\n")
+    console.print(build_table(adjusted_findings))
+    console.print("")
+
+    print_compliance_results(console, context, adjusted_findings)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_risk_adjustment.py
+++ b/tests/test_risk_adjustment.py
@@ -1,0 +1,91 @@
+import sys
+from pathlib import Path
+
+import pytest
+import types
+
+if "structlog" not in sys.modules:
+    class _StubLogger:
+        def info(self, *args, **kwargs):
+            pass
+
+        def warning(self, *args, **kwargs):
+            pass
+
+        def error(self, *args, **kwargs):
+            pass
+
+        def debug(self, *args, **kwargs):
+            pass
+
+    sys.modules["structlog"] = types.SimpleNamespace(get_logger=lambda: _StubLogger())
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXOPS_ROOT = REPO_ROOT / "fixops-blended-enterprise"
+if str(FIXOPS_ROOT) not in sys.path:
+    sys.path.insert(0, str(FIXOPS_ROOT))
+
+from src.services.risk_scorer import ContextualRiskScorer  # noqa: E402
+from src.services.compliance_engine import ComplianceEngine  # noqa: E402
+
+
+@pytest.fixture()
+def scorer() -> ContextualRiskScorer:
+    return ContextualRiskScorer()
+
+
+def test_contextual_risk_scorer_downgrades_low_impact(scorer: ContextualRiskScorer) -> None:
+    findings = [
+        {
+            "id": "CVE-LOW-1",
+            "severity": "critical",
+        }
+    ]
+    business_context = {
+        "customer_impact": "low",
+        "data_classification": ["public"],
+        "deployment_frequency": "quarterly",
+    }
+
+    adjusted = scorer.apply(findings, business_context)
+    assert adjusted[0]["scanner_severity"] == "CRITICAL"
+    assert adjusted[0]["fixops_severity"] == "HIGH"
+    assert adjusted[0]["risk_adjustment"] == -1
+
+
+def test_contextual_risk_scorer_upgrades_high_impact(scorer: ContextualRiskScorer) -> None:
+    findings = [
+        {
+            "id": "CVE-HIGH-1",
+            "severity": "medium",
+        }
+    ]
+    business_context = {
+        "customer_impact": "mission_critical",
+        "data_classification": ["pii", "financial"],
+        "deployment_frequency": "continuous",
+    }
+
+    adjusted = scorer.apply(findings, business_context)
+    assert adjusted[0]["scanner_severity"] == "MEDIUM"
+    assert adjusted[0]["fixops_severity"] == "HIGH"
+    assert adjusted[0]["risk_adjustment"] == 1
+
+
+def test_compliance_engine_uses_adjusted_severity() -> None:
+    engine = ComplianceEngine()
+    findings = [
+        {
+            "id": "CVE-0001",
+            "scanner_severity": "low",
+            "fixops_severity": "critical",
+            "risk_adjustment": 2,
+        }
+    ]
+
+    result = engine._evaluate_framework("pci_dss", findings, {})
+    assert result["status"] == "non_compliant"
+    assert result["highest_scanner_severity"] == "LOW"
+    assert result["highest_fixops_severity"] == "CRITICAL"
+    assert result["findings"][0]["scanner_severity"] == "LOW"
+    assert result["findings"][0]["fixops_severity"] == "CRITICAL"


### PR DESCRIPTION
## Summary
- add a reusable ContextualRiskScorer and wire the decision engine to adjust findings before downstream processing
- introduce a compliance engine that records both scanner and FixOps severities when evaluating frameworks
- surface the reclassified severities in the real CVE playbook script and cover upgrades/downgrades with unit tests

## Testing
- pytest tests/test_risk_adjustment.py

------
https://chatgpt.com/codex/tasks/task_e_68df35073d7083299b36d69557820b2d