### PR TITLE
Add golden regression store and coverage-aware validation

### DIFF
--- a/fixops-blended-enterprise/data/golden_regression_cases.json
+++ b/fixops-blended-enterprise/data/golden_regression_cases.json
@@ -1,0 +1,49 @@
+{
+  "cases": [
+    {
+      "case_id": "payment-2024-01",
+      "service_name": "payment-service",
+      "cve_id": "CVE-2024-1111",
+      "decision": "pass",
+      "confidence": 0.94,
+      "timestamp": "2024-01-15T12:00:00Z",
+      "expected_behavior": "Checkout path blocks SQL injection payloads",
+      "notes": "Validated after hotfix deployment",
+      "evidence_link": "https://fixops.example.com/evidence/payment-2024-01"
+    },
+    {
+      "case_id": "payment-2024-02",
+      "service_name": "payment-service",
+      "cve_id": "CVE-2023-9999",
+      "decision": "pass",
+      "confidence": 0.91,
+      "timestamp": "2024-03-02T08:30:00Z",
+      "expected_behavior": "Dependency patch eliminated vulnerable version",
+      "notes": "Validated against historical staging run",
+      "evidence_link": "https://fixops.example.com/evidence/payment-2024-02"
+    },
+    {
+      "case_id": "inventory-2023-05",
+      "service_name": "inventory-service",
+      "cve_id": "CVE-2024-3333",
+      "decision": "fail",
+      "confidence": 0.62,
+      "timestamp": "2023-11-18T19:45:00Z",
+      "expected_behavior": "Fix should prevent unauthenticated access to stock data",
+      "notes": "Regression detected after rollback of authorization middleware",
+      "evidence_link": "https://fixops.example.com/evidence/inventory-2023-05",
+      "failure_reason": "Regression reintroduced after service refactor"
+    },
+    {
+      "case_id": "shared-2023-09",
+      "service_name": "shared-platform",
+      "cve_id": "CVE-2023-7777",
+      "decision": "pass",
+      "confidence": 0.87,
+      "timestamp": "2023-09-27T10:10:00Z",
+      "expected_behavior": "Shared middleware rejects malicious deserialization payload",
+      "notes": "Multi-tenant validation run",
+      "evidence_link": "https://fixops.example.com/evidence/shared-2023-09"
+    }
+  ]
+}

--- a/fixops-blended-enterprise/src/services/decision_engine.py
+++ b/fixops-blended-enterprise/src/services/decision_engine.py
@@ -14,6 +14,7 @@ import structlog
 
 from src.config.settings import get_settings
 from src.services.cache_service import CacheService
+from src.services.golden_regression_store import GoldenRegressionStore
 from src.db.session import DatabaseManager
 
 logger = structlog.get_logger()
@@ -712,12 +713,75 @@ class DecisionEngine:
             }
     
     async def _real_golden_regression_validation(self, context):
-        """Real golden regression validation using historical decisions"""
+        """Real golden regression validation using historical decisions."""
+        store = GoldenRegressionStore.get_instance()
+
+        cve_ids = []
+        for finding in context.security_findings:
+            cve_value = finding.get("cve") or finding.get("cve_id") or finding.get("cveId")
+            if cve_value:
+                cve_ids.append(str(cve_value))
+
+        lookup = store.lookup_cases(service_name=context.service_name, cve_ids=cve_ids)
+        matched_cases = lookup.get("cases", [])
+        total_matches = len(matched_cases)
+
+        if total_matches == 0:
+            coverage_map = {
+                "service": False,
+                "cves": {cve: False for cve in cve_ids},
+            }
+            return {
+                "status": "no_coverage",
+                "confidence": 0.0,
+                "validation_passed": False,
+                "matched_cases": [],
+                "counts": {
+                    "total_matches": 0,
+                    "service_matches": lookup.get("service_matches", 0),
+                    "cve_matches": lookup.get("cve_matches", {}),
+                    "passes": 0,
+                    "failures": 0,
+                },
+                "failures": [],
+                "coverage": coverage_map,
+            }
+
+        pass_cases: List[Dict[str, Any]] = []
+        fail_cases: List[Dict[str, Any]] = []
+        total_confidence = 0.0
+
+        for case in matched_cases:
+            total_confidence += float(case.get("confidence", 0.0))
+            decision = str(case.get("decision", "")).lower()
+            if decision == "pass":
+                pass_cases.append(case)
+            elif decision == "fail":
+                fail_cases.append(case)
+
+        average_confidence = total_confidence / total_matches if total_matches else 0.0
+        validation_passed = len(fail_cases) == 0
+        status = "validated" if validation_passed else "regression_failed"
+
+        coverage_map = {
+            "service": lookup.get("service_matches", 0) > 0,
+            "cves": {cve: lookup.get("cve_matches", {}).get(cve, 0) > 0 for cve in cve_ids},
+        }
+
         return {
-            "status": "validated",
-            "confidence": 0.89,
-            "similar_cases": 23,
-            "validation_passed": True
+            "status": status,
+            "confidence": average_confidence,
+            "validation_passed": validation_passed,
+            "matched_cases": matched_cases,
+            "counts": {
+                "total_matches": total_matches,
+                "service_matches": lookup.get("service_matches", 0),
+                "cve_matches": lookup.get("cve_matches", {}),
+                "passes": len(pass_cases),
+                "failures": len(fail_cases),
+            },
+            "failures": fail_cases,
+            "coverage": coverage_map,
         }
     
     async def _real_policy_evaluation(self, context, enriched_context):

--- a/fixops-blended-enterprise/src/services/golden_regression_store.py
+++ b/fixops-blended-enterprise/src/services/golden_regression_store.py
@@ -1,0 +1,199 @@
+"""Golden regression dataset loader for historical validation results."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Iterable, List, Optional
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class RegressionCase:
+    """Represents a single historical regression validation case."""
+
+    case_id: str
+    service_name: str
+    cve_id: Optional[str]
+    decision: str
+    confidence: float
+    timestamp: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "RegressionCase":
+        """Create a regression case from a raw payload."""
+        base_fields = {
+            "case_id",
+            "service_name",
+            "cve_id",
+            "decision",
+            "confidence",
+            "timestamp",
+        }
+
+        missing = [field for field in ("case_id", "service_name", "decision") if not payload.get(field)]
+        if missing:
+            raise ValueError(f"Regression case missing required fields: {', '.join(missing)}")
+
+        decision = str(payload.get("decision", "")).strip().lower()
+        if decision not in {"pass", "fail"}:
+            raise ValueError(f"Unsupported regression decision '{decision}'")
+
+        metadata = {k: v for k, v in payload.items() if k not in base_fields}
+        confidence = float(payload.get("confidence", 0.0))
+        return cls(
+            case_id=str(payload.get("case_id")),
+            service_name=str(payload.get("service_name")),
+            cve_id=payload.get("cve_id"),
+            decision=decision,
+            confidence=confidence,
+            timestamp=payload.get("timestamp"),
+            metadata=metadata,
+        )
+
+    def to_response(self) -> Dict[str, Any]:
+        """Convert to a serializable representation for API responses."""
+        return {
+            "case_id": self.case_id,
+            "service_name": self.service_name,
+            "cve_id": self.cve_id,
+            "decision": self.decision,
+            "confidence": self.confidence,
+            "timestamp": self.timestamp,
+            "metadata": self.metadata,
+        }
+
+
+class GoldenRegressionStore:
+    """Loads and queries historical regression validation cases."""
+
+    _instance: Optional["GoldenRegressionStore"] = None
+    _lock: Lock = Lock()
+
+    def __init__(self, dataset_path: Optional[Path] = None) -> None:
+        self.dataset_path = Path(dataset_path) if dataset_path else self._default_dataset_path()
+        self._cases_by_id: Dict[str, RegressionCase] = {}
+        self._cases_by_service: Dict[str, List[RegressionCase]] = {}
+        self._cases_by_cve: Dict[str, List[RegressionCase]] = {}
+        self._load_dataset()
+
+    @classmethod
+    def get_instance(cls, dataset_path: Optional[Path] = None) -> "GoldenRegressionStore":
+        """Return a singleton instance, reloading if a new dataset path is provided."""
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls(dataset_path)
+            elif dataset_path and Path(dataset_path) != cls._instance.dataset_path:
+                cls._instance = cls(dataset_path)
+            return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton instance (useful for tests)."""
+        with cls._lock:
+            cls._instance = None
+
+    def lookup_cases(
+        self,
+        service_name: Optional[str] = None,
+        cve_ids: Optional[Iterable[str]] = None,
+    ) -> Dict[str, Any]:
+        """Return cases that match the provided service or CVE identifiers."""
+        matched_cases: Dict[str, Dict[str, Any]] = {}
+        service_match_count = 0
+        cve_match_counts: Dict[str, int] = {}
+
+        def _add_case(case: RegressionCase, match_type: str, match_value: str) -> None:
+            context = {"type": match_type, "value": match_value}
+            existing = matched_cases.get(case.case_id)
+            if not existing:
+                record = case.to_response()
+                record["match_context"] = [context]
+                matched_cases[case.case_id] = record
+            else:
+                contexts = existing.setdefault("match_context", [])
+                if context not in contexts:
+                    contexts.append(context)
+
+        if service_name:
+            key = service_name.strip().lower()
+            for case in self._cases_by_service.get(key, []):
+                service_match_count += 1
+                _add_case(case, "service", service_name)
+
+        if cve_ids:
+            for cve in cve_ids:
+                if not cve:
+                    continue
+                normalized = cve.strip().lower()
+                cases = self._cases_by_cve.get(normalized, [])
+                cve_match_counts[cve] = len(cases)
+                for case in cases:
+                    _add_case(case, "cve", cve)
+
+        return {
+            "cases": list(matched_cases.values()),
+            "service_matches": service_match_count,
+            "cve_matches": cve_match_counts,
+        }
+
+    def _load_dataset(self) -> None:
+        """Load regression cases from the dataset file."""
+        self._cases_by_id.clear()
+        self._cases_by_service.clear()
+        self._cases_by_cve.clear()
+
+        if not self.dataset_path.exists():
+            logger.warning(
+                "Golden regression dataset not found; regression validation will have no coverage",
+                path=str(self.dataset_path),
+            )
+            return
+
+        try:
+            with self.dataset_path.open("r", encoding="utf-8") as handle:
+                raw = json.load(handle)
+        except Exception as exc:
+            logger.error("Failed to load golden regression dataset", error=str(exc))
+            return
+
+        cases_payload = raw.get("cases") if isinstance(raw, dict) else raw
+        if not isinstance(cases_payload, list):
+            logger.error("Golden regression dataset is malformed", path=str(self.dataset_path))
+            return
+
+        for entry in cases_payload:
+            try:
+                case = RegressionCase.from_dict(entry)
+            except Exception as exc:
+                logger.warning("Skipping invalid regression case", error=str(exc), entry=entry)
+                continue
+
+            self._cases_by_id[case.case_id] = case
+
+            service_key = case.service_name.strip().lower()
+            self._cases_by_service.setdefault(service_key, []).append(case)
+
+            if case.cve_id:
+                cve_key = str(case.cve_id).strip().lower()
+                self._cases_by_cve.setdefault(cve_key, []).append(case)
+
+        logger.info(
+            "Golden regression dataset loaded",
+            path=str(self.dataset_path),
+            cases=len(self._cases_by_id),
+            services=len(self._cases_by_service),
+            cves=len(self._cases_by_cve),
+        )
+
+    @staticmethod
+    def _default_dataset_path() -> Path:
+        return Path(__file__).resolve().parents[2] / "data" / "golden_regression_cases.json"
+
+
+__all__ = ["GoldenRegressionStore", "RegressionCase"]

--- a/tests/test_golden_regression.py
+++ b/tests/test_golden_regression.py
@@ -1,0 +1,190 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import types
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "fixops-blended-enterprise"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+if "structlog" not in sys.modules:
+    structlog_stub = types.ModuleType("structlog")
+
+    class _Logger:
+        def __getattr__(self, _name):
+            def _noop(*_args, **_kwargs):
+                return None
+
+            return _noop
+
+    def get_logger(*_args, **_kwargs):
+        return _Logger()
+
+    structlog_stub.get_logger = get_logger
+    sys.modules["structlog"] = structlog_stub
+
+if "src.config.settings" not in sys.modules:
+    settings_module = types.ModuleType("src.config.settings")
+
+    class _Settings:
+        DEMO_MODE = False
+        EMERGENT_LLM_KEY = None
+        VECTOR_DB_URL = None
+        SECURITY_PATTERNS_DB_URL = None
+        JIRA_URL = None
+        JIRA_USERNAME = None
+        JIRA_API_TOKEN = None
+        CONFLUENCE_URL = None
+        CONFLUENCE_USERNAME = None
+        CONFLUENCE_API_TOKEN = None
+        THREAT_INTEL_API_KEY = None
+        DEMO_VECTOR_DB_PATTERNS = 0
+        DEMO_GOLDEN_REGRESSION_CASES = 0
+        DEMO_BUSINESS_CONTEXTS = 0
+
+    def get_settings():
+        return _Settings()
+
+    settings_module.get_settings = get_settings
+    sys.modules["src.config.settings"] = settings_module
+    config_package = sys.modules.setdefault("src.config", types.ModuleType("src.config"))
+    config_package.settings = settings_module
+
+if "src.services.cache_service" not in sys.modules:
+    cache_module = types.ModuleType("src.services.cache_service")
+
+    class CacheService:
+        _instance = None
+
+        @classmethod
+        def get_instance(cls):
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+        async def get(self, *_args, **_kwargs):
+            return None
+
+        async def set(self, *_args, **_kwargs):
+            return None
+
+    cache_module.CacheService = CacheService
+    sys.modules["src.services.cache_service"] = cache_module
+
+if "src.db.session" not in sys.modules:
+    session_module = types.ModuleType("src.db.session")
+
+    class _AsyncSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def commit(self):
+            return None
+
+        async def rollback(self):
+            return None
+
+        async def close(self):
+            return None
+
+    class DatabaseManager:
+        @classmethod
+        async def get_session(cls):
+            return _AsyncSession()
+
+        @classmethod
+        async def get_session_context(cls):
+            return _AsyncSession()
+
+    session_module.DatabaseManager = DatabaseManager
+    sys.modules["src.db.session"] = session_module
+
+from src.services.decision_engine import DecisionContext, DecisionEngine
+from src.services.golden_regression_store import GoldenRegressionStore
+
+
+@pytest.fixture(autouse=True)
+def reset_golden_regression_store():
+    GoldenRegressionStore.reset_instance()
+    yield
+    GoldenRegressionStore.reset_instance()
+
+
+def test_store_lookup_matches_service_and_cve():
+    store = GoldenRegressionStore.get_instance()
+
+    lookup = store.lookup_cases(
+        service_name="payment-service", cve_ids=["CVE-2024-1111"]
+    )
+
+    assert lookup["service_matches"] == 2
+    assert lookup["cve_matches"] == {"CVE-2024-1111": 1}
+
+    case_ids = {case["case_id"] for case in lookup["cases"]}
+    assert case_ids == {"payment-2024-01", "payment-2024-02"}
+
+    context_map = {case["case_id"]: case["match_context"] for case in lookup["cases"]}
+    assert {entry["type"] for entry in context_map["payment-2024-01"]} == {"service", "cve"}
+    assert {entry["type"] for entry in context_map["payment-2024-02"]} == {"service"}
+
+
+def test_regression_validation_passes_with_historical_support():
+    engine = DecisionEngine()
+    context = DecisionContext(
+        service_name="payment-service",
+        environment="production",
+        business_context={},
+        security_findings=[{"cve": "CVE-2024-1111"}],
+    )
+
+    result = asyncio.run(engine._real_golden_regression_validation(context))
+
+    assert result["status"] == "validated"
+    assert result["validation_passed"] is True
+    assert result["counts"]["total_matches"] == 2
+    assert result["counts"]["passes"] == 2
+    assert result["coverage"]["service"] is True
+    assert result["coverage"]["cves"]["CVE-2024-1111"] is True
+
+
+def test_regression_validation_surfaces_failures():
+    engine = DecisionEngine()
+    context = DecisionContext(
+        service_name="inventory-service",
+        environment="production",
+        business_context={},
+        security_findings=[{"cve_id": "CVE-2024-3333"}],
+    )
+
+    result = asyncio.run(engine._real_golden_regression_validation(context))
+
+    assert result["status"] == "regression_failed"
+    assert result["validation_passed"] is False
+    assert result["counts"]["failures"] == 1
+    assert result["failures"][0]["case_id"] == "inventory-2023-05"
+    assert result["coverage"]["service"] is True
+    assert result["coverage"]["cves"]["CVE-2024-3333"] is True
+
+
+def test_regression_validation_handles_missing_coverage():
+    engine = DecisionEngine()
+    context = DecisionContext(
+        service_name="unknown-service",
+        environment="production",
+        business_context={},
+        security_findings=[{"cve": "CVE-0000-0000"}],
+    )
+
+    result = asyncio.run(engine._real_golden_regression_validation(context))
+
+    assert result["status"] == "no_coverage"
+    assert result["validation_passed"] is False
+    assert result["counts"]["total_matches"] == 0
+    assert result["coverage"]["service"] is False
+    assert result["coverage"]["cves"]["CVE-0000-0000"] is False


### PR DESCRIPTION
## Summary
- add a golden regression data store for loading and matching historical cases
- integrate the decision engine with the store to return coverage-aware regression validation details
- seed historical regression cases and add focused tests that exercise pass/fail/no-coverage paths

## Testing
- pytest tests/test_golden_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68df1ed639848329924e3bced93280b5