### PR TITLE
Add FSI security sales objection handling guide

### DIFF
--- a/docs/security_sales_objections.md
+++ b/docs/security_sales_objections.md
@@ -1,0 +1,47 @@
+# Addressing Enterprise Security Sales Objections
+
+This guide summarizes common objections raised by financial services institutions (FSIs) when evaluating Fixops' open-source security platform and provides actionable responses to help move deals forward.
+
+## 1. "You do not understand the people and processes in FSIs"
+
+**Why it matters:** Security leadership in FSIs prioritizes governance, risk management, and compliance (GRC). They expect vendors to demonstrate an understanding of regulatory oversight, stakeholder alignment, and change-management practices.
+
+**How to respond:**
+- Map Fixops' value to specific FSI personas (CISO, head of security engineering, compliance, audit).
+- Share playbooks that show how Fixops integrates into existing SOC processes, including escalation paths and audit-ready reporting.
+- Provide case studies or design partners that illustrate successful rollouts with similar governance requirements.
+
+## 2. "Open source is not trusted in the security world"
+
+**Why it matters:** Decision makers worry about supply-chain risk, unmaintained dependencies, and lack of vendor accountability.
+
+**How to respond:**
+- Highlight Fixops' secure software development lifecycle (SSDL), including signed releases, SBOM generation, and regular third-party audits.
+- Emphasize the transparency benefits of open source (independent code review, faster vulnerability discovery, community hardening).
+- Offer enterprise support SLAs, dedicated security response processes, and indemnification options.
+
+## 3. "You do not have a production implementation"
+
+**Why it matters:** Referenceable customers reduce perceived risk and accelerate procurement.
+
+**How to respond:**
+- Develop a lighthouse implementation with a design partner and capture measurable outcomes (MTTR reduction, compliance efficiency).
+- Package a proof-of-value (PoV) methodology with clear success criteria, timeline, and executive reporting cadence.
+- Provide a roadmap for post-PoV hardening, including managed onboarding and ongoing success reviews.
+
+## 4. "How can FSIs trust Fixops?"
+
+**Why it matters:** Trust encompasses technical assurance, operational maturity, and business continuity.
+
+**How to respond:**
+- Share security posture artifacts (SOC 2 roadmap, penetration testing results, responsible disclosure policy).
+- Document resiliency measures such as disaster recovery runbooks, uptime targets, and dependency management.
+- Provide executive briefings that align Fixops' mission with FSI strategic priorities and demonstrate long-term viability.
+
+## Next Steps for Sales Enablement
+
+1. Build a central repository of collateral (personas, PoV plans, compliance mappings) accessible to presales and account teams.
+2. Train sales engineers on articulating the open-source value proposition alongside enterprise-grade assurances.
+3. Collect feedback from early prospects to refine messaging and address emerging objections quickly.
+
+Use this guide to reinforce credibility with FSI buyers and to provide a structured response to common concerns about Fixops' open-source security platform.


### PR DESCRIPTION
## Summary
- add documentation that outlines responses to common FSI objections about Fixops' open-source security platform
- highlight actionable next steps for presales teams to build trust with financial services buyers

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df82bb9ac483298c7706b4badd1516