### PR TITLE
Add contributor reputation metrics and QA validation to marketplace

### DIFF
--- a/fixops-blended-enterprise/docs/MARKETPLACE_GUIDE.md
+++ b/fixops-blended-enterprise/docs/MARKETPLACE_GUIDE.md
@@ -1,0 +1,39 @@
+# FixOps Marketplace Guide
+
+The FixOps marketplace curates reusable remediation content, compliance guardrails, and attack simulations submitted by the community. This guide outlines how contributors participate, how content is validated, and how reputation incentives are calculated.
+
+## Contribution Workflow
+
+1. **Submit content** via the `/api/v1/marketplace/contribute` endpoint with a metadata manifest and artifact payload.
+2. **Automated validation** runs immediately, linting the artifact for unresolved TODO markers, checking metadata completeness, and inspecting the payload for embedded tests or controls.
+3. **QA status** is assigned (`passed`, `warning`, or `failed`) along with a summary of automated findings. Items with warnings or failures are flagged for manual curation before being promoted.
+4. **Marketplace listing** occurs once QA gates are satisfied, making the content available through browse, recommendation, and purchase flows.
+
+## Automated Quality Gates
+
+The validation pipeline combines lightweight linting with heuristic harness checks:
+
+- **Metadata completeness** ensures descriptions, SSDLC stages, and compliance frameworks are present.
+- **Artifact linting** blocks submissions that still contain TODO/FIXME placeholders or are empty.
+- **Harness detection** rewards content that ships runnable policies, tests, or control bundles.
+
+Quality telemetry is surfaced through the `/api/v1/marketplace/stats` endpoint so dashboards can monitor adoption versus QA posture.
+
+## Reputation & Incentives
+
+Contributor reputation is recalculated on every contribution, adoption event, and rating:
+
+- **Submissions** earn baseline points once automated QA runs.
+- **Validated submissions** (QA status `passed`) boost a contributor's QA credibility score.
+- **Adoption events** count each marketplace purchase/download tied to the contributor's assets.
+- **Community ratings** aggregate per-item feedback to reward consistently high-quality content.
+
+Reputation scores combine these vectors to highlight top performers, and the `/api/v1/marketplace/contributors` endpoint exposes leaderboards for gamification dashboards.
+
+### Incentive Ideas
+
+- **Spotlight placement** for contributors with the highest reputation scores each month.
+- **Revenue sharing** or credit pools triggered when adoption thresholds are met.
+- **Early access** to enterprise roadmap features for validated, high-impact authors.
+
+These incentives encourage a virtuous cycle where contributors invest in quality, benefiting consumers who rely on trustworthy remediation content.

--- a/fixops-blended-enterprise/src/services/marketplace.py
+++ b/fixops-blended-enterprise/src/services/marketplace.py
@@ -7,7 +7,6 @@ Marketplace service with file persistence and validation (enterprise-ready stub)
 from __future__ import annotations
 
 import json
-import os
 import uuid
 import hmac
 import hashlib
@@ -17,7 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 import structlog
 
 logger = structlog.get_logger()
@@ -26,6 +25,45 @@ DATA_DIR = Path("/app/data/marketplace")
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 ITEMS_FILE = DATA_DIR / "items.json"
 PURCHASES_FILE = DATA_DIR / "purchases.json"
+CONTRIBUTORS_FILE = DATA_DIR / "contributors.json"
+
+
+class QAStatus(str, Enum):
+    passed = "passed"
+    warning = "warning"
+    failed = "failed"
+
+
+@dataclass
+class ContributorProfile:
+    author: str
+    organization: str
+    submissions: int = 0
+    validated_submissions: int = 0
+    adoption_events: int = 0
+    total_rating: float = 0.0
+    rating_count: int = 0
+    average_rating: float = 0.0
+    reputation_score: float = 0.0
+    last_submission_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContributorProfile":
+        return cls(
+            author=data.get("author", "unknown"),
+            organization=data.get("organization", "unknown"),
+            submissions=data.get("submissions", 0),
+            validated_submissions=data.get("validated_submissions", 0),
+            adoption_events=data.get("adoption_events", 0),
+            total_rating=data.get("total_rating", 0.0),
+            rating_count=data.get("rating_count", 0),
+            average_rating=data.get("average_rating", 0.0),
+            reputation_score=data.get("reputation_score", 0.0),
+            last_submission_at=data.get("last_submission_at"),
+        )
 
 
 class ContentType(str, Enum):
@@ -55,9 +93,13 @@ class MarketplaceItemModel(BaseModel):
     metadata: Dict[str, Any] = {}
     rating: float = 4.6
     downloads: int = 0
+    rating_count: int = 0
     version: str = Field(default="1.0.0")
     created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     updated_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    qa_status: QAStatus = QAStatus.passed
+    qa_summary: str = Field(default="")
+    qa_checks: Dict[str, Any] = Field(default_factory=dict)
 
 
 @dataclass
@@ -77,12 +119,17 @@ class MarketplaceItem:
     version: str = "1.0.0"
     created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    rating_count: int = 0
+    qa_status: QAStatus = QAStatus.passed
+    qa_summary: str = ""
+    qa_checks: Dict[str, Any] = field(default_factory=dict)
 
 
 class MarketplaceService:
     def __init__(self, secret: Optional[str] = None) -> None:
         self._items: List[MarketplaceItem] = []
         self._purchases: Dict[str, Dict[str, Any]] = {}
+        self._contributors: Dict[str, ContributorProfile] = {}
         self._secret = (secret or "fixops-secret").encode("utf-8")
         self._load()
         if not self._items:
@@ -98,16 +145,34 @@ class MarketplaceService:
         try:
             if ITEMS_FILE.exists():
                 raw = json.loads(ITEMS_FILE.read_text(encoding='utf-8'))
-                self._items = [MarketplaceItem(**i) for i in raw]
+                self._items = []
+                for item in raw:
+                    enriched = {
+                        **item,
+                        "rating_count": item.get("rating_count", 0),
+                        "qa_status": QAStatus(item.get("qa_status", QAStatus.passed.value)),
+                        "qa_summary": item.get("qa_summary", ""),
+                        "qa_checks": item.get("qa_checks", {}),
+                    }
+                    self._items.append(MarketplaceItem(**enriched))
             if PURCHASES_FILE.exists():
                 self._purchases = json.loads(PURCHASES_FILE.read_text(encoding='utf-8'))
+            if CONTRIBUTORS_FILE.exists():
+                raw_contributors = json.loads(CONTRIBUTORS_FILE.read_text(encoding='utf-8'))
+                self._contributors = {
+                    key: ContributorProfile.from_dict(value) for key, value in raw_contributors.items()
+                }
         except Exception as e:
             logger.error("Failed to load marketplace data", error=str(e))
 
     def _persist(self):
         try:
-            ITEMS_FILE.write_text(json.dumps([asdict(i) for i in self._items], indent=2), encoding='utf-8')
+            ITEMS_FILE.write_text(json.dumps([asdict(i) for i in self._items], indent=2, default=str), encoding='utf-8')
             PURCHASES_FILE.write_text(json.dumps(self._purchases, indent=2), encoding='utf-8')
+            CONTRIBUTORS_FILE.write_text(
+                json.dumps({k: v.to_dict() for k, v in self._contributors.items()}, indent=2),
+                encoding='utf-8'
+            )
         except Exception as e:
             logger.error("Failed to persist marketplace data", error=str(e))
 
@@ -124,7 +189,10 @@ class MarketplaceService:
                 tags=["pci", "payments", "rego"],
                 metadata={"version": "1.0.0"},
                 rating=4.8,
+                rating_count=87,
                 downloads=312,
+                qa_status=QAStatus.passed,
+                qa_summary="All automated checks passed",
             ),
             MarketplaceItem(
                 id=str(uuid.uuid4()),
@@ -137,7 +205,10 @@ class MarketplaceService:
                 tags=["sast", "baseline"],
                 metadata={"coverage": "core"},
                 rating=4.5,
+                rating_count=54,
                 downloads=198,
+                qa_status=QAStatus.passed,
+                qa_summary="Static analysis harness validated",
             ),
             MarketplaceItem(
                 id=str(uuid.uuid4()),
@@ -151,7 +222,10 @@ class MarketplaceService:
                 tags=["ransomware", "ttp"],
                 metadata={"techniques": ["T1486", "T1059"]},
                 rating=4.4,
+                rating_count=23,
                 downloads=77,
+                qa_status=QAStatus.warning,
+                qa_summary="Scenario requires manual validation of TTP coverage",
             ),
         ]
         self._items.extend(demo_items)
@@ -168,6 +242,88 @@ class MarketplaceService:
             })
         except Exception as e:
             raise ValueError(f"Invalid content fields: {e}")
+
+    def _run_automated_validation(self, content: Dict[str, Any], artifact: Any) -> Dict[str, Any]:
+        checks: Dict[str, Dict[str, Any]] = {}
+        issues: List[str] = []
+
+        # Check 1: metadata completeness
+        metadata_complete = all(
+            bool(content.get(field)) for field in ["description", "compliance_frameworks", "ssdlc_stages"]
+        )
+        checks["metadata_completeness"] = {
+            "status": "passed" if metadata_complete else "failed",
+            "details": "Description, frameworks and SSDLC stages provided" if metadata_complete else "Missing key metadata fields",
+        }
+        if not metadata_complete:
+            issues.append("Metadata incomplete - requires author follow-up")
+
+        # Check 2: artifact linting (basic TODO/FIXME detection)
+        artifact_blob = ""
+        if isinstance(artifact, (dict, list)):
+            artifact_blob = json.dumps(artifact)
+        elif artifact is not None:
+            artifact_blob = str(artifact)
+        lint_passed = bool(artifact_blob.strip()) and not any(marker in artifact_blob for marker in ["TODO", "FIXME", "TEMP"])
+        checks["artifact_lint"] = {
+            "status": "passed" if lint_passed else "failed",
+            "details": "Artifact payload present and free of TODO/FIXME markers"
+            if lint_passed
+            else "Artifact missing or contains unresolved TODO/FIXME markers",
+        }
+        if not lint_passed:
+            issues.append("Automated linting flagged unresolved tasks or empty payload")
+
+        # Check 3: lightweight test harness (size/structure heuristic)
+        harness_passed = False
+        if isinstance(artifact, dict):
+            harness_passed = any(key in artifact for key in ["tests", "policies", "controls"])
+        elif isinstance(artifact, list):
+            harness_passed = len(artifact) > 0
+        else:
+            harness_passed = len(artifact_blob) > 50
+        checks["harness_validation"] = {
+            "status": "passed" if harness_passed else "warning",
+            "details": "Content includes executable checks or sufficient detail"
+            if harness_passed
+            else "Content lacks explicit test harness details",
+        }
+        if not harness_passed:
+            issues.append("Validation harness could not be confirmed - manual QA recommended")
+
+        if any(check["status"] == "failed" for check in checks.values()):
+            status = QAStatus.failed
+        elif any(check["status"] == "warning" for check in checks.values()):
+            status = QAStatus.warning
+        else:
+            status = QAStatus.passed
+
+        return {
+            "status": status,
+            "issues": issues,
+            "checks": checks,
+            "summary": "; ".join(issues) if issues else "All automated checks passed",
+        }
+
+    def _contributor_key(self, author: str, organization: str) -> str:
+        return f"{author}::{organization}".lower()
+
+    def _get_or_create_profile(self, author: str, organization: str) -> ContributorProfile:
+        key = self._contributor_key(author, organization)
+        if key not in self._contributors:
+            self._contributors[key] = ContributorProfile(author=author, organization=organization)
+        return self._contributors[key]
+
+    def _recalculate_reputation(self, profile: ContributorProfile) -> None:
+        submission_score = profile.submissions * 10
+        adoption_score = profile.adoption_events * 5
+        rating_score = profile.average_rating * profile.rating_count
+        qa_rate = (
+            profile.validated_submissions / profile.submissions * 20
+            if profile.submissions
+            else 0
+        )
+        profile.reputation_score = round(submission_score + adoption_score + rating_score + qa_rate, 2)
 
     # Tokenization
     def _sign_token(self, purchase_id: str, expires_in_minutes: int = 60) -> str:
@@ -235,6 +391,8 @@ class MarketplaceService:
 
     async def contribute_content(self, content: Dict[str, Any], author: str, organization: str) -> str:
         self._validate_content(content)
+        artifact = content.get("metadata", {}).get("content")
+        qa_result = self._run_automated_validation(content, artifact)
         item = MarketplaceItem(
             id=str(uuid.uuid4()),
             name=content["name"],
@@ -248,9 +406,21 @@ class MarketplaceService:
             metadata={**content.get("metadata", {}), "author": author, "organization": organization},
             rating=4.7,
             downloads=0,
-            version=content.get("version", "1.0.0")
+            rating_count=0,
+            version=content.get("version", "1.0.0"),
+            qa_status=qa_result["status"],
+            qa_summary=qa_result["summary"],
+            qa_checks=qa_result["checks"],
         )
         self._items.append(item)
+
+        profile = self._get_or_create_profile(author, organization)
+        profile.submissions += 1
+        if qa_result["status"] == QAStatus.passed:
+            profile.validated_submissions += 1
+        profile.last_submission_at = item.created_at
+        self._recalculate_reputation(profile)
+
         self._persist()
         return item.id
 
@@ -283,9 +453,73 @@ class MarketplaceService:
         }
         self._purchases[purchase_id] = record
         item.downloads += 1
+
+        author = item.metadata.get("author")
+        author_org = item.metadata.get("organization")
+        if author and author_org:
+            profile = self._get_or_create_profile(author, author_org)
+            profile.adoption_events += 1
+            self._recalculate_reputation(profile)
+
         self._persist()
         token = self._sign_token(purchase_id)
         return {**record, "download_token": token}
+
+    async def rate_content(self, item_id: str, rating: float, reviewer: str) -> Dict[str, Any]:
+        if rating < 1 or rating > 5:
+            raise ValueError("Rating must be between 1 and 5")
+        item = next((i for i in self._items if i.id == item_id), None)
+        if not item:
+            raise ValueError("Item not found")
+        item.rating_count += 1
+        item.rating = round(((item.rating * (item.rating_count - 1)) + rating) / item.rating_count, 2)
+        item.updated_at = datetime.now(timezone.utc).isoformat()
+
+        author = item.metadata.get("author")
+        author_org = item.metadata.get("organization")
+        if author and author_org:
+            profile = self._get_or_create_profile(author, author_org)
+            profile.rating_count += 1
+            profile.total_rating += rating
+            profile.average_rating = round(profile.total_rating / profile.rating_count, 2)
+            self._recalculate_reputation(profile)
+
+        self._persist()
+        return {
+            "item_id": item_id,
+            "rating": item.rating,
+            "rating_count": item.rating_count,
+            "reviewer": reviewer,
+        }
+
+    async def get_contributor_metrics(
+        self,
+        author: Optional[str] = None,
+        organization: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        profiles = list(self._contributors.values())
+        if author:
+            profiles = [p for p in profiles if p.author.lower() == author.lower()]
+        if organization:
+            profiles = [p for p in profiles if p.organization.lower() == organization.lower()]
+        profiles.sort(key=lambda p: p.reputation_score, reverse=True)
+        return [p.to_dict() for p in profiles]
+
+    async def get_quality_summary(self) -> Dict[str, Any]:
+        status_counts = {status.value: 0 for status in QAStatus}
+        for item in self._items:
+            status_counts[item.qa_status.value] = status_counts.get(item.qa_status.value, 0) + 1
+        return {
+            "status_counts": status_counts,
+            "validated_ratio": (
+                status_counts.get(QAStatus.passed.value, 0) / len(self._items)
+                if self._items
+                else 0
+            ),
+        }
+
+    async def get_item(self, item_id: str) -> Optional[MarketplaceItem]:
+        return next((i for i in self._items if i.id == item_id), None)
 
     async def download_by_token(self, token: str) -> Dict[str, Any]:
         ok, purchase_id = self._verify_token(token)


### PR DESCRIPTION
## Summary
- add contributor profile tracking, QA automation, and reputation scoring to the marketplace service
- expose quality telemetry, contributor leaderboards, and rating APIs for dashboards to consume
- document contributor incentives and the validation workflow in the marketplace guide

## Testing
- pytest *(fails: missing `requests` dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a4f73eb0832989779687577e8a24