### PR TITLE
Optimize backend pipeline matching and document ingestion architecture

### DIFF
--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -5,6 +5,7 @@ from collections import Counter
 from typing import Any, Dict, Iterable, List, Optional
 
 from .normalizers import (
+    CVERecordSummary,
     NormalizedCVEFeed,
     NormalizedSARIF,
     NormalizedSBOM,
@@ -20,9 +21,62 @@ def _lower(value: Optional[str]) -> Optional[str]:
 class PipelineOrchestrator:
     """Derive intermediate insights from the uploaded artefacts."""
 
+    @staticmethod
+    def _extract_component_name(row: Dict[str, Any]) -> Optional[str]:
+        """Return the first non-empty component identifier in a design row."""
+
+        for key in ("component", "Component", "service"):
+            value = row.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+        return None
+
+    @staticmethod
+    def _build_finding_search_text(finding: SarifFinding) -> str:
+        """Concatenate searchable portions of a SARIF finding once."""
+
+        parts: List[str] = []
+        if finding.file:
+            parts.append(finding.file)
+        if finding.message:
+            parts.append(finding.message)
+        if finding.rule_id:
+            parts.append(finding.rule_id)
+        analysis_target = finding.raw.get("analysisTarget") if finding.raw else None
+        if analysis_target:
+            try:
+                parts.append(
+                    json.dumps(
+                        analysis_target,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                )
+            except TypeError:
+                parts.append(str(analysis_target))
+        return " ".join(parts)
+
+    @staticmethod
+    def _build_record_search_text(record: CVERecordSummary) -> str:
+        parts: List[str] = []
+        if record.cve_id:
+            parts.append(record.cve_id)
+        if record.title:
+            parts.append(record.title)
+        if record.severity:
+            parts.append(record.severity)
+        try:
+            parts.append(
+                json.dumps(record.raw, sort_keys=True, separators=(",", ":"))
+            )
+        except TypeError:
+            parts.append(str(record.raw))
+        return " ".join(parts)
+
     def _match_components(
         self,
-        design_rows: Iterable[Dict[str, Any]],
         sbom_components: Iterable[SBOMComponent],
     ) -> Dict[str, SBOMComponent]:
         lookup: Dict[str, SBOMComponent] = {}
@@ -32,34 +86,6 @@ class PipelineOrchestrator:
                 lookup[key] = component
         return lookup
 
-    def _group_findings(
-        self, design_name: str, findings: Iterable[SarifFinding]
-    ) -> List[dict[str, Any]]:
-        results: List[dict[str, Any]] = []
-        token = _lower(design_name)
-        for finding in findings:
-            haystack = "".join(
-                str(part or "")
-                for part in (
-                    finding.file,
-                    json.dumps(finding.raw.get("analysisTarget", {})),
-                )
-            )
-            if token and token in haystack.lower():
-                results.append(finding.to_dict())
-        return results
-
-    def _group_cves(
-        self, design_name: str, records: Iterable
-    ) -> List[dict[str, Any]]:
-        token = _lower(design_name)
-        grouped: List[dict[str, Any]] = []
-        for record in records:
-            serialised = json.dumps(record.raw)
-            if token and token in serialised.lower():
-                grouped.append(record.to_dict())
-        return grouped
-
     def run(
         self,
         design_dataset: Dict[str, Any],
@@ -68,46 +94,58 @@ class PipelineOrchestrator:
         cve: NormalizedCVEFeed,
     ) -> Dict[str, Any]:
         rows: List[Dict[str, Any]] = list(design_dataset.get("rows", []))
-        design_components = [
-            row.get("component")
-            or row.get("Component")
-            or row.get("service")
-            for row in rows
-        ]
-        design_components = [name for name in design_components if name]
 
-        sbom_lookup = self._match_components(rows, sbom.components)
+        design_components: List[str] = []
+        tokens: Dict[str, Optional[str]] = {}
+        for row in rows:
+            name = self._extract_component_name(row)
+            if name:
+                design_components.append(name)
+                tokens[name] = _lower(name)
+
+        lookup_tokens = {
+            token for token in tokens.values() if token
+        }
+
+        sbom_lookup = self._match_components(sbom.components)
 
         findings_by_level = Counter(
             finding.level or "none" for finding in sarif.findings
         )
-        exploited_records = [record for record in cve.records if record.exploited]
+        exploited_count = sum(1 for record in cve.records if record.exploited)
+
+        finding_matches: Dict[str, List[dict[str, Any]]] = {
+            token: [] for token in lookup_tokens
+        }
+        for finding in sarif.findings:
+            payload = finding.to_dict()
+            haystack = self._build_finding_search_text(finding).lower()
+            for token in lookup_tokens:
+                if token in haystack:
+                    finding_matches[token].append(dict(payload))
+
+        cve_matches: Dict[str, List[dict[str, Any]]] = {
+            token: [] for token in lookup_tokens
+        }
+        for record in cve.records:
+            payload = record.to_dict()
+            haystack = self._build_record_search_text(record).lower()
+            for token in lookup_tokens:
+                if token in haystack:
+                    cve_matches[token].append(dict(payload))
 
         crosswalk: List[dict[str, Any]] = []
         for row in rows:
-            component_name = (
-                row.get("component")
-                or row.get("Component")
-                or row.get("service")
-            )
-            match = sbom_lookup.get(_lower(component_name)) if component_name else None
-            matched_findings = (
-                self._group_findings(component_name, sarif.findings)
-                if component_name
-                else []
-            )
-            matched_cves = (
-                self._group_cves(component_name, cve.records)
-                if component_name
-                else []
-            )
+            component_name = self._extract_component_name(row)
+            token = tokens.get(component_name) if component_name else None
+            match = sbom_lookup.get(token) if token else None
 
             crosswalk.append(
                 {
                     "design_row": row,
                     "sbom_component": match.to_dict() if match else None,
-                    "findings": matched_findings,
-                    "cves": matched_cves,
+                    "findings": list(finding_matches.get(token, [])),
+                    "cves": list(cve_matches.get(token, [])),
                 }
             )
 
@@ -129,7 +167,7 @@ class PipelineOrchestrator:
             },
             "cve_summary": {
                 **cve.metadata,
-                "exploited_count": len(exploited_records),
+                "exploited_count": exploited_count,
             },
             "crosswalk": crosswalk,
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,107 @@
+# FixOps Ingestion Demo — Architecture Overview
+
+This document explains how the backend FastAPI service ingests security artefacts, normalises
+them, and correlates the data during the pipeline run. It is written for a mixed audience — you
+do not need to be a developer to understand how requests move through the system.
+
+## Key Components
+
+1. **FastAPI Application (`backend/app.py`)**
+   - Exposes `/inputs/*` endpoints for uploading CSV, SBOM, CVE/KEV, and SARIF artefacts.
+   - Stores the normalised artefacts in `app.state.artifacts` for later orchestration.
+   - Delegates all parsing to `InputNormalizer` and orchestration to `PipelineOrchestrator`.
+2. **Normalisation Layer (`backend/normalizers.py`)**
+   - Converts raw files into structured Python dataclasses using maintained OSS parsers.
+   - Provides consistent `to_dict()` helpers so the API can serialise responses quickly.
+3. **Pipeline Orchestrator (`backend/pipeline.py`)**
+   - Correlates design rows with SBOM components, SARIF findings, and CVE entries.
+   - Generates summary statistics for each artefact and returns a crosswalk.
+
+## Lifecycle of a Typical Session
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as FastAPI App
+    participant Normalizer
+    participant Store as In-Memory Store
+    participant Orchestrator
+
+    User->>API: POST /inputs/design (CSV)
+    API->>Normalizer: parse design CSV
+    Normalizer-->>API: columns + rows
+    API->>Store: save design dataset
+
+    User->>API: POST /inputs/sbom (SBOM file)
+    API->>Normalizer: load_sbom
+    Normalizer-->>API: NormalizedSBOM
+    API->>Store: save SBOM
+
+    User->>API: POST /inputs/cve (JSON feed)
+    API->>Normalizer: load_cve_feed
+    Normalizer-->>API: NormalizedCVEFeed
+    API->>Store: save CVE feed
+
+    User->>API: POST /inputs/sarif (JSON)
+    API->>Normalizer: load_sarif
+    Normalizer-->>API: NormalizedSARIF
+    API->>Store: save SARIF
+
+    User->>API: POST /pipeline/run
+    API->>Orchestrator: run(design, sbom, sarif, cve)
+    Orchestrator-->>API: summaries + crosswalk
+    API-->>User: HTTP 200 + JSON report
+```
+
+## Deployment Boundary Diagram
+
+```mermaid
+graph TD
+    subgraph Client
+        Browser[(Analyst UI)]
+    end
+    subgraph Backend
+        A[FastAPI App]
+        B[InputNormalizer]
+        C[PipelineOrchestrator]
+    end
+    subgraph OSS Parsers
+        L[lib4sbom]
+        S[sarif-om]
+        CVE[cvelib]
+        SY[snyk-to-sarif]
+    end
+
+    Browser -->|HTTP| A
+    A --> B
+    A --> C
+    B --> L
+    B --> S
+    B --> CVE
+    B --> SY
+```
+
+## Data Flow Highlights
+
+- All uploads are processed in-memory. The service does **not** persist artefacts to disk or a
+  database.
+- Normalised objects store both concise fields (e.g., component name, severity) and the full raw
+  payload for traceability.
+- The orchestrator pre-computes lowercase lookup tables so string matching across artefacts is
+  fast and case-insensitive.
+
+## Error Handling & Logging
+
+- Upload endpoints wrap parser failures in HTTP 400 errors with human-readable messages.
+- Normalisation emits structured debug logs containing metadata counts to help operations teams
+  inspect the flow without dumping raw artefacts.
+- Missing artefacts during `/pipeline/run` result in a single 400 response that names every missing
+  stage.
+
+## Extensibility Considerations
+
+- Additional artefact types can be added by creating new normaliser methods and storing the result
+  in `app.state.artifacts` using the `_store` helper.
+- The orchestrator is deliberately stateless; you can replace it or run multiple orchestrators in
+  parallel by instantiating a new object per request or per tenant.
+

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,78 @@
+# Data Model Reference
+
+The backend works with a handful of lightweight dataclasses that wrap the parsed artefacts. This
+section translates those models into plain language and explains key invariants.
+
+## SBOM Normalisation
+
+- **`SBOMComponent`** (`backend/normalizers.py`)
+  - Represents a single software component from the SBOM.
+  - Fields:
+    - `name` (string, required): component identifier.
+    - `version` (string, optional): semantic version.
+    - `purl` (string, optional): Package URL when provided.
+    - `licenses` (list of strings): flattened licence names.
+    - `supplier` (string, optional): supplier name; may come from nested dicts.
+    - `raw` (dict): full package object for traceability.
+  - Invariants: `raw` always contains the original SBOM entry to avoid data loss.
+
+- **`NormalizedSBOM`**
+  - Bundles the full parsed SBOM document, component list, relationships, services, vulnerabilities,
+    and metadata counters.
+  - Metadata includes `component_count`, `relationship_count`, `service_count`, and
+    `vulnerability_count` for quick dashboards.
+
+## CVE / KEV Feeds
+
+- **`CVERecordSummary`**
+  - Focuses on correlation-friendly fields: `cve_id`, `title`, `severity`, `exploited`, and `raw`.
+  - `exploited` is derived from several possible boolean flags for broad feed compatibility.
+
+- **`NormalizedCVEFeed`**
+  - Contains the list of `CVERecordSummary` objects, any validation errors, and metadata such as
+    `record_count` and optional `validation_errors` counts.
+  - Records may include validation issues even if ingestion succeeded; callers should inspect both
+    `records` and `errors`.
+
+## SARIF Findings
+
+- **`SarifFinding`**
+  - Stores the fields needed for quick inspection: `rule_id`, `message`, `level`, `file`, `line`,
+    and the original `raw` SARIF result.
+
+- **`NormalizedSARIF`**
+  - Tracks SARIF `version`, optional `$schema` URI, a list of tool names, extracted findings, and
+    metadata counters for runs and findings.
+
+## Design Dataset
+
+- Captured as a plain dictionary: `{ "columns": [..], "rows": [ {"component": ...}, ... ] }`.
+- Rows can use any of the keys `component`, `Component`, or `service`. The orchestrator trims white
+  space and handles case-insensitive matching.
+
+## Crosswalk Output
+
+- Each entry returned by `PipelineOrchestrator.run()` looks like:
+
+```json
+{
+  "design_row": {"component": "Payment-Service"},
+  "sbom_component": {
+    "name": "payment-service",
+    "version": "1.0.0",
+    "licenses": [],
+    "supplier": null,
+    "purl": null,
+    "raw": {"name": "payment-service", "version": "1.0.0"}
+  },
+  "findings": [{"rule_id": "CWE-79", "message": "…"}],
+  "cves": [{"cve_id": "CVE-2023-0001", "severity": "HIGH"}]
+}
+```
+
+- Summaries in the response provide quick statistics without reprocessing:
+  - `design_summary`: total rows and unique component names.
+  - `sbom_summary`: SBOM metadata plus source document name.
+  - `sarif_summary`: run/finding counts, severity histogram, and tools used.
+  - `cve_summary`: record counts and exploited record tally.
+

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,26 @@
+# External Integrations
+
+The ingestion service relies on a set of third-party libraries to parse and validate uploaded
+artefacts. This guide captures their purpose, how they are invoked, and the fallback behaviour if a
+library is unavailable.
+
+| Integration | Purpose | Invocation Point | Failure Mode |
+| ----------- | ------- | ---------------- | ------------ |
+| `lib4sbom` | Parses SPDX/CycloneDX SBOM documents into a common representation. | `InputNormalizer.load_sbom()` creates an `SBOMParser`, reads the SBOM string, and extracts packages/relationships/services. | Raises whichever exception the parser surfaces; the API wraps it in HTTP 400. |
+| `cvelib` | Validates CVE/KEV records against the official schema. | `InputNormalizer.load_cve_feed()` calls `CveRecord.validate()` when available. | Missing library downgrades to best-effort ingestion; validation errors are appended to the response. |
+| `snyk-to-sarif` | Converts proprietary Snyk JSON payloads into SARIF. | `InputNormalizer.load_sarif()` detects missing `runs` and calls `convert`/`to_sarif` if the converter exists. | Absent converter means non-SARIF payloads are rejected with `ValueError`. |
+| `sarif-om` | Provides typed SARIF models for introspection. | `InputNormalizer.load_sarif()` instantiates `SarifLog` to carry metadata and normalise access. | Missing dependency is fatal at import time, raising `RuntimeError` to alert deployers. |
+
+## HTTP Surface
+
+- All endpoints are public within the FastAPI app. In production deployments you should layer
+  authentication (API keys or OAuth) in front of the service.
+- CORS is currently wide open to support local prototyping. Restrict `allow_origins` before exposing
+  the API on the internet.
+
+## Observability
+
+- The backend uses Python's standard logging. Configure log handlers in your deployment environment
+  (e.g., JSON logs shipped to ELK) to capture normalisation metadata and error traces.
+- Add request/response metrics by integrating FastAPI middleware such as Prometheus or OpenTelemetry.
+

--- a/docs/LINE_BY_LINE.md
+++ b/docs/LINE_BY_LINE.md
@@ -1,0 +1,46 @@
+# Line-by-Line Commentary
+
+This document summarises every meaningful line in the FixOps ingestion backend. Blank lines and
+obvious imports are grouped for readability.
+
+## `backend/app.py`
+
+| Lines | Description |
+| ----- | ----------- |
+| 1-15 | Future import, stdlib modules, FastAPI primitives, local dependencies, and logger set-up. |
+| 18-31 | `create_app()` initialises FastAPI with permissive CORS, instantiates the normaliser and orchestrator, and prepares `app.state` storage. |
+| 33-36 | `_store()` helper centralises writing artefacts to `app.state.artifacts` with debug logging. |
+| 38-55 | `/inputs/design` endpoint reads the uploaded CSV, strips empty rows, enforces non-empty payloads, stores the dataset, and returns metadata plus raw rows. |
+| 57-74 | `/inputs/sbom` endpoint normalises SBOM bytes through `InputNormalizer.load_sbom`, stores the result, and returns metadata plus a preview of the first five components. Exceptions are wrapped in HTTP 400 responses. |
+| 76-91 | `/inputs/cve` endpoint normalises CVE/KEV JSON, stores the canonical feed, and responds with record counts and validation errors. |
+| 93-108 | `/inputs/sarif` endpoint loads SARIF JSON (including optional Snyk conversion), stores the result, and returns metadata alongside tool names. |
+| 110-126 | `/pipeline/run` validates that all artefacts have been uploaded, invokes the orchestrator, and streams the correlation output. Missing artefacts trigger an HTTP 400 with a structured `missing` list. |
+
+## `backend/normalizers.py`
+
+| Lines | Description |
+| ----- | ----------- |
+| 1-27 | Imports, optional dependency guards, and logger configuration. Missing optional libs degrade gracefully except `sarif-om`, which raises immediately. |
+| 30-52 | `SBOMComponent` dataclass captures the subset of SBOM component fields used downstream and ensures `to_dict()` preserves the embedded raw package. |
+| 55-76 | `NormalizedSBOM` dataclass stores the parsed SBOM document alongside related lists and metadata; `to_dict()` serialises nested components. |
+| 79-92 | `CVERecordSummary` dataclass shrinks CVE entries to key attributes plus raw payload. |
+| 95-108 | `NormalizedCVEFeed` dataclass provides a uniform structure for CVE data and validation errors. |
+| 111-125 | `SarifFinding` dataclass represents an extracted SARIF result. |
+| 128-143 | `NormalizedSARIF` dataclass encapsulates SARIF metadata and findings with serialisation support. |
+| 146-158 | `InputNormalizer.__init__` captures SBOM type preferences and `_ensure_text` converts any raw input (bytes, file-like, str) into UTF-8 strings. |
+| 160-207 | `load_sbom` leverages `lib4sbom` to parse the document, builds `SBOMComponent` objects with defensive defaults, and compiles metadata counts. |
+| 209-272 | `load_cve_feed` decodes JSON feeds that may be dicts or lists, validates entries with `cvelib` when available, normalises identifiers/title/severity, and records validation errors. |
+| 274-324 | `load_sarif` parses JSON, optionally converts Snyk payloads to SARIF, instantiates `SarifLog`, extracts tool names/findings, and builds metadata counts. |
+
+## `backend/pipeline.py`
+
+| Lines | Description |
+| ----- | ----------- |
+| 1-18 | Imports, shared `_lower` helper, and class docstring. |
+| 21-36 | `_extract_component_name` trims design row values across canonical keys. |
+| 38-58 | `_build_finding_search_text` assembles a searchable string once per SARIF finding, handling non-serialisable targets gracefully. |
+| 60-69 | `_build_record_search_text` mirrors the search-text logic for CVE records. |
+| 71-79 | `_match_components` constructs a lowercase index of SBOM components for constant-time lookups. |
+| 81-137 | `run()` builds the design list, precomputes lowercase tokens, indexes SBOM components, aggregates severity/exploitation statistics, and precomputes finding/CVE matches per token to avoid redundant scans. |
+| 139-158 | Crosswalk assembly attaches matches to each design row and prepares the final response with summaries for every artefact. |
+

--- a/tests/test_pipeline_matching.py
+++ b/tests/test_pipeline_matching.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from backend.pipeline import PipelineOrchestrator
+from backend.normalizers import (
+    CVERecordSummary,
+    NormalizedCVEFeed,
+    NormalizedSARIF,
+    NormalizedSBOM,
+    SBOMComponent,
+    SarifFinding,
+)
+
+
+def build_orchestrator_payload():
+    design_dataset = {
+        "columns": ["component"],
+        "rows": [
+            {"component": "Payment-Service"},
+            {"component": " inventory "},
+            {"component": "Auth"},
+        ],
+    }
+
+    sbom = NormalizedSBOM(
+        format="cyclonedx",
+        document={"name": "demo"},
+        components=[
+            SBOMComponent(name="payment-service", version="1.0.0"),
+            SBOMComponent(name="inventory", version="2.3.1"),
+        ],
+        relationships=[],
+        services=[],
+        vulnerabilities=[],
+        metadata={"component_count": 2},
+    )
+
+    sarif = NormalizedSARIF(
+        version="2.1.0",
+        schema_uri=None,
+        tool_names=["StaticAnalyzer"],
+        findings=[
+            SarifFinding(
+                rule_id="CWE-79",
+                message="Reflected XSS in payment-service template",
+                level="error",
+                file="services/payment-service/app.py",
+                line=42,
+                raw={"analysisTarget": {"uri": "payment-service"}},
+            ),
+            SarifFinding(
+                rule_id="CWE-20",
+                message="Validate input handling",
+                level="warning",
+                file="services/auth/forms.py",
+                line=12,
+                raw={"analysisTarget": {"uri": "auth"}},
+            ),
+        ],
+        metadata={"run_count": 1, "finding_count": 2},
+    )
+
+    cve = NormalizedCVEFeed(
+        records=[
+            CVERecordSummary(
+                cve_id="CVE-2023-0001",
+                title="Auth credential leak",
+                severity="HIGH",
+                exploited=True,
+                raw={"systems": ["auth"], "details": "credential exposure"},
+            ),
+            CVERecordSummary(
+                cve_id="CVE-2023-7777",
+                title="Inventory overflow",
+                severity="MEDIUM",
+                exploited=False,
+                raw={"component": "inventory"},
+            ),
+        ],
+        errors=[],
+        metadata={"record_count": 2},
+    )
+
+    return design_dataset, sbom, sarif, cve
+
+
+def test_pipeline_crosswalk_reuses_precomputed_matches():
+    orchestrator = PipelineOrchestrator()
+    design_dataset, sbom, sarif, cve = build_orchestrator_payload()
+
+    result = orchestrator.run(
+        design_dataset=design_dataset, sbom=sbom, sarif=sarif, cve=cve
+    )
+
+    assert result["design_summary"]["row_count"] == 3
+    crosswalk = result["crosswalk"]
+
+    payment_entry = crosswalk[0]
+    assert payment_entry["sbom_component"]["name"] == "payment-service"
+    assert payment_entry["findings"][0]["rule_id"] == "CWE-79"
+    assert not payment_entry["cves"]
+
+    inventory_entry = crosswalk[1]
+    assert inventory_entry["sbom_component"]["name"] == "inventory"
+    assert inventory_entry["cves"][0]["cve_id"] == "CVE-2023-7777"
+
+    auth_entry = crosswalk[2]
+    assert auth_entry["findings"][0]["rule_id"] == "CWE-20"
+    assert auth_entry["cves"][0]["cve_id"] == "CVE-2023-0001"
+    assert result["cve_summary"]["exploited_count"] == 1
+    assert result["sarif_summary"]["severity_breakdown"]["error"] == 1
+
+


### PR DESCRIPTION
## Summary
- precompute pipeline lookup tokens to avoid repeated rescans when correlating design rows with findings and CVEs
- add backend documentation covering architecture, data model, line-by-line commentary, and external integrations
- introduce a targeted orchestrator test to exercise the new matching behaviour

## Testing
- pytest tests/test_pipeline_matching.py


------
https://chatgpt.com/codex/tasks/task_e_68e11c2593b483298b3315f11c5d847c