### PR TITLE
Use live policy decision metrics outside demo mode

### DIFF
--- a/fixops-blended-enterprise/src/db/decision_metrics_repository.py
+++ b/fixops-blended-enterprise/src/db/decision_metrics_repository.py
@@ -1,0 +1,120 @@
+"""Utility helpers for aggregating policy decision metrics.
+
+This module keeps the heavy SQL aggregation logic out of the
+``DecisionEngine`` so that the service can stay focused on orchestration
+instead of database plumbing.  The repository exposes a single async helper
+that summarises counts and latency statistics from ``PolicyDecisionLog``
+records.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Iterable, List
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.security_sqlite import PolicyDecisionLog
+
+
+class DecisionMetricsRepository:
+    """Aggregate decision metrics from the policy decision logs."""
+
+    HIGH_CONFIDENCE_THRESHOLD = 0.8
+
+    @staticmethod
+    async def get_metrics(session: AsyncSession) -> Dict[str, Any]:
+        """Return aggregated metrics for decision logs.
+
+        The method issues a small number of SQL queries to fetch counts and
+        execution-time statistics.  Percentiles are computed in Python to stay
+        compatible with SQLite, which lacks ``percentile_cont``.
+        """
+
+        aggregates_stmt = select(
+            func.count(PolicyDecisionLog.id).label("total"),
+            func.sum(
+                case((PolicyDecisionLog.decision == "DEFER", 1), else_=0)
+            ).label("pending"),
+            func.sum(
+                case(
+                    (PolicyDecisionLog.confidence >= DecisionMetricsRepository.HIGH_CONFIDENCE_THRESHOLD, 1),
+                    else_=0,
+                )
+            ).label("high_conf"),
+            func.sum(
+                case((PolicyDecisionLog.decision != "DEFER", 1), else_=0)
+            ).label("consensus"),
+            func.avg(PolicyDecisionLog.execution_time_ms).label("avg_latency_ms"),
+            func.sum(
+                case(
+                    (func.length(func.trim(PolicyDecisionLog.input_context)) > 2, 1),
+                    else_=0,
+                )
+            ).label("enriched"),
+        )
+
+        result = await session.execute(aggregates_stmt)
+        total, pending, high_conf, consensus, avg_latency_ms, enriched = result.one()
+
+        total = total or 0
+        pending = pending or 0
+        high_conf = high_conf or 0
+        consensus = consensus or 0
+        avg_latency_ms = avg_latency_ms or 0.0
+        enriched = enriched or 0
+
+        latencies_stmt = select(PolicyDecisionLog.execution_time_ms).where(
+            PolicyDecisionLog.execution_time_ms.is_not(None)
+        )
+        latency_result = await session.execute(latencies_stmt)
+        latencies_ms = [value for value in latency_result.scalars() if value is not None]
+
+        metrics: Dict[str, Any] = {
+            "total_decisions": int(total),
+            "pending_review": int(pending),
+            "high_confidence_rate": DecisionMetricsRepository._safe_ratio(high_conf, total),
+            "context_enrichment_rate": DecisionMetricsRepository._safe_ratio(enriched, total),
+            "avg_decision_latency_us": float(avg_latency_ms) * 1000.0,
+            "consensus_rate": DecisionMetricsRepository._safe_ratio(consensus, total),
+            "evidence_records": int(total),
+            "audit_compliance": 1.0,
+            "latency_percentiles_us": DecisionMetricsRepository._latency_percentiles(latencies_ms),
+        }
+
+        return metrics
+
+    @staticmethod
+    def _safe_ratio(numerator: float, denominator: float) -> float:
+        if not denominator:
+            return 0.0
+        return float(numerator) / float(denominator)
+
+    @staticmethod
+    def _latency_percentiles(latencies_ms: Iterable[float]) -> Dict[str, float]:
+        values: List[float] = sorted(float(v) for v in latencies_ms if v is not None)
+        if not values:
+            return {"p50": 0.0, "p95": 0.0, "p99": 0.0}
+
+        return {
+            "p50": DecisionMetricsRepository._percentile(values, 0.5) * 1000.0,
+            "p95": DecisionMetricsRepository._percentile(values, 0.95) * 1000.0,
+            "p99": DecisionMetricsRepository._percentile(values, 0.99) * 1000.0,
+        }
+
+    @staticmethod
+    def _percentile(sorted_values: List[float], percentile: float) -> float:
+        if not sorted_values:
+            return 0.0
+
+        k = (len(sorted_values) - 1) * percentile
+        lower_index = math.floor(k)
+        upper_index = math.ceil(k)
+
+        if lower_index == upper_index:
+            return sorted_values[int(k)]
+
+        lower_value = sorted_values[lower_index]
+        upper_value = sorted_values[upper_index]
+        return lower_value + (upper_value - lower_value) * (k - lower_index)

--- a/tests/test_decision_metrics.py
+++ b/tests/test_decision_metrics.py
@@ -1,0 +1,144 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+
+# Ensure the application package is importable
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT / "fixops-blended-enterprise"))
+
+TEST_DB_PATH = REPO_ROOT / "test_decision_metrics.db"
+
+
+os.environ.setdefault("DATABASE_URL", f"sqlite+aiosqlite:///{TEST_DB_PATH}")
+os.environ.setdefault("DEMO_MODE", "false")
+os.environ.setdefault("REDIS_URL", "memory://")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from src.config.settings import get_settings
+
+get_settings.cache_clear()
+settings = get_settings()
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from src.db.session import DatabaseManager
+from src.models.base_sqlite import Base
+from src.models.security_sqlite import PolicyDecisionLog, PolicyRule
+from src.services.decision_engine import DecisionEngine
+
+
+@pytest_asyncio.fixture
+async def seeded_policy_logs():
+    if DatabaseManager._engine is not None:
+        await DatabaseManager.close()
+
+    engine = create_async_engine(
+        os.environ["DATABASE_URL"],
+        poolclass=NullPool,
+        future=True,
+    )
+    DatabaseManager._engine = engine
+    DatabaseManager._sessionmaker = async_sessionmaker(  # type: ignore[attr-defined]
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=True,
+        autocommit=False,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with DatabaseManager.get_session_context() as session:
+        rule = PolicyRule(
+            name="payment-sla",
+            description="Test policy rule",
+            rule_type="python",
+            rule_content="print('enforce')",
+            priority=100,
+            active=True,
+            default_decision="ALLOW",
+        )
+        rule.set_environments(["production"])
+        rule.set_data_classifications(["pci"])
+
+        session.add(rule)
+        await session.flush()
+
+        log_allow = PolicyDecisionLog(
+            policy_rule_id=rule.id,
+            decision="ALLOW",
+            confidence=0.92,
+            decision_rationale="Meets policy requirements",
+            execution_time_ms=10.0,
+            policy_version="1.0",
+        )
+        log_allow.set_input_context({"enriched": True})
+
+        log_block = PolicyDecisionLog(
+            policy_rule_id=rule.id,
+            decision="BLOCK",
+            confidence=0.85,
+            decision_rationale="Violates policy",
+            execution_time_ms=20.0,
+            policy_version="1.0",
+        )
+        log_block.set_input_context({"enriched": True, "sources": ["sbom"]})
+
+        log_defer = PolicyDecisionLog(
+            policy_rule_id=rule.id,
+            decision="DEFER",
+            confidence=0.55,
+            decision_rationale="Needs manual review",
+            execution_time_ms=40.0,
+            policy_version="1.0",
+        )
+        log_defer.set_input_context({})
+
+        session.add_all([log_allow, log_block, log_defer])
+
+    yield
+
+    await DatabaseManager.close()
+    if TEST_DB_PATH.exists():
+        TEST_DB_PATH.unlink()
+
+
+@pytest.mark.asyncio
+async def test_get_decision_metrics_production(seeded_policy_logs):
+    engine = DecisionEngine()
+    engine.demo_mode = False
+
+    metrics = await engine.get_decision_metrics()
+
+    assert metrics["demo_mode"] is False
+    assert metrics["total_decisions"] == 3
+    assert metrics["pending_review"] == 1
+    assert metrics["high_confidence_rate"] == pytest.approx(2 / 3)
+    assert metrics["consensus_rate"] == pytest.approx(2 / 3)
+    assert metrics["context_enrichment_rate"] == pytest.approx(2 / 3)
+    assert metrics["avg_decision_latency_us"] == pytest.approx((10 + 20 + 40) / 3 * 1000)
+
+    percentiles = metrics["latency_percentiles_us"]
+    assert percentiles["p50"] == pytest.approx(20_000.0)
+    assert percentiles["p95"] == pytest.approx(38_000.0)
+    assert percentiles["p99"] == pytest.approx(39_600.0)
+
+
+@pytest.mark.asyncio
+async def test_get_decision_metrics_demo_mode():
+    engine = DecisionEngine()
+    engine.demo_mode = True
+    await engine._initialize_demo_mode()
+
+    metrics = await engine.get_decision_metrics()
+
+    assert metrics["demo_mode"] is True
+    assert metrics["total_decisions"] == 234
+    assert metrics["mode_indicator"] == "🎭 DEMO MODE"


### PR DESCRIPTION
## Summary
- add a dedicated repository for aggregating policy decision log counts, rates, and latency percentiles
- update the decision engine metrics endpoint to use live database values in production while keeping demo snapshots unchanged
- cover the new behaviour with async tests that seed policy decision logs for both production and demo scenarios

## Testing
- pytest tests/test_decision_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68dee022d66483298888fcc6207b283d