### PR TITLE
Enforce allowlisted storage directory security

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Hardening Guidance
+
+This document captures the operational safeguards required to run FixOps in
+regulated environments.
+
+## Overlay allowlist enforcement
+
+- **Pre-provision allowlisted roots.** Create each directory listed in
+  `overlay.allowed_data_roots` ahead of time and ensure they are owned by the
+  deployment user (or `root`) with permissions no broader than `0750`.
+- **Avoid temporary paths.** Deny roots located under world-writable parents
+  such as `/tmp`; FixOps now validates each ancestor before any artefacts are
+  written.
+- **Do not rely on lazy creation.** The API and CLI refuse to create new
+  directories when the allowlisted root is missing or has insecure ownership or
+  permission bits. Provision infrastructure via configuration management so the
+  process only touches vetted locations.
+
+## Runtime hygiene
+
+- **Review overlay changes.** Treat modifications to `config/fixops.overlay.yml`
+  as privileged operations; they control directory allowlists, upload limits,
+  and authentication settings.
+- **Rotate API tokens.** When using `auth.strategy: token`, rotate entries in
+  `overlay.auth_tokens` and redeploy. Tokens are cached at startup.
+- **Harden filesystem backups.** Evidence bundles and artefact archives contain
+  sensitive remediation details. Store backups on encrypted volumes that inherit
+  the same ownership/permission checks described above.

--- a/fastapi/middleware/__init__.py
+++ b/fastapi/middleware/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["CORSMiddleware"]

--- a/fastapi/middleware/cors.py
+++ b/fastapi/middleware/cors.py
@@ -1,0 +1,21 @@
+from typing import Iterable, Sequence
+
+
+class CORSMiddleware:
+    def __init__(
+        self,
+        app,
+        *,
+        allow_origins: Sequence[str] | Iterable[str] = (),
+        allow_credentials: bool = False,
+        allow_methods: Sequence[str] | Iterable[str] = (),
+        allow_headers: Sequence[str] | Iterable[str] = (),
+    ) -> None:
+        self.app = app
+        self.allow_origins = tuple(allow_origins)
+        self.allow_credentials = allow_credentials
+        self.allow_methods = tuple(allow_methods)
+        self.allow_headers = tuple(allow_headers)
+
+
+__all__ = ["CORSMiddleware"]

--- a/fastapi/security.py
+++ b/fastapi/security.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+
+class APIKeyHeader:
+    def __init__(self, name: str, *, auto_error: bool = True) -> None:
+        self.name = name
+        self.auto_error = auto_error
+
+
+__all__ = ["APIKeyHeader"]

--- a/fixops/cli.py
+++ b/fixops/cli.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Iterable, Optional
 from backend.normalizers import InputNormalizer, NormalizedCVEFeed, NormalizedSARIF, NormalizedSBOM
 from backend.pipeline import PipelineOrchestrator
 from fixops.configuration import OverlayConfig, load_overlay
-from fixops.paths import ensure_secure_directory
+from fixops.paths import ensure_secure_directory, verify_allowlisted_path
 from fixops.storage import ArtefactArchive
 
 
@@ -198,18 +198,18 @@ def _handle_run(args: argparse.Namespace) -> int:
         auto_refresh = overlay.exploit_signals.get("auto_refresh")
         if isinstance(auto_refresh, dict):
             auto_refresh["enabled"] = False
+    allowlist = overlay.allowed_data_roots or (Path("data").resolve(),)
     for directory in overlay.data_directories.values():
-        ensure_secure_directory(directory)
+        secure_path = verify_allowlisted_path(directory, allowlist)
+        ensure_secure_directory(secure_path)
 
     archive_dir = overlay.data_directories.get("archive_dir")
     if archive_dir is None:
-        root = (
-            overlay.allowed_data_roots[0]
-            if overlay.allowed_data_roots
-            else Path("data").resolve()
-        )
+        root = allowlist[0]
+        root = verify_allowlisted_path(root, allowlist)
         archive_dir = (root / "archive" / overlay.mode).resolve()
-    archive = ArtefactArchive(archive_dir)
+    archive_dir = verify_allowlisted_path(archive_dir, allowlist)
+    archive = ArtefactArchive(archive_dir, allowlist=allowlist)
 
     normalizer = InputNormalizer()
     inputs = _load_inputs(

--- a/fixops/paths.py
+++ b/fixops/paths.py
@@ -4,6 +4,32 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
+from typing import Iterable, Tuple
+
+
+def _current_uid() -> int | None:
+    try:
+        return os.getuid()
+    except AttributeError:  # pragma: no cover - not available on Windows
+        return None
+
+
+def _validate_directory_security(path: Path, expected_uid: int | None) -> None:
+    if not path.exists():
+        raise PermissionError(
+            f"Allowlisted directory '{path}' does not exist; create it with secure permissions"
+        )
+    stats = path.stat()
+    if stats.st_mode & stat.S_IWOTH:
+        raise PermissionError(
+            f"Directory '{path}' must not be world-writable for regulated storage"
+        )
+    if expected_uid is not None and hasattr(stats, "st_uid"):
+        if stats.st_uid not in {expected_uid, 0}:
+            raise PermissionError(
+                f"Directory '{path}' is owned by unexpected UID {stats.st_uid}; "
+                "ensure the FixOps process or root owns data roots"
+            )
 
 
 def ensure_secure_directory(path: Path, mode: int = 0o750) -> Path:
@@ -32,4 +58,41 @@ def ensure_secure_directory(path: Path, mode: int = 0o750) -> Path:
     return resolved
 
 
-__all__ = ["ensure_secure_directory"]
+def verify_allowlisted_path(path: Path, allowlist: Iterable[Path]) -> Path:
+    """Resolve *path* and ensure it resides inside a secure allowlisted root."""
+
+    resolved_allowlist: Tuple[Path, ...] = tuple(root.resolve() for root in allowlist)
+    if not resolved_allowlist:
+        raise PermissionError("No data directory allowlist configured")
+
+    resolved = path.expanduser().resolve()
+    matched_root: Path | None = None
+    for root in resolved_allowlist:
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            continue
+        else:
+            matched_root = root
+            break
+
+    if matched_root is None:
+        raise PermissionError(
+            f"Directory '{resolved}' is not within the configured allowlist: {resolved_allowlist}"
+        )
+
+    uid = _current_uid()
+    ancestor = matched_root
+    _validate_directory_security(ancestor, uid)
+    for parent in resolved.parents:
+        if matched_root in {parent, parent.resolve()}:
+            break
+        if parent.exists():
+            _validate_directory_security(parent, uid)
+    if resolved.exists():
+        _validate_directory_security(resolved, uid)
+
+    return resolved
+
+
+__all__ = ["ensure_secure_directory", "verify_allowlisted_path"]

--- a/tests/test_backend_security.py
+++ b/tests/test_backend_security.py
@@ -1,0 +1,29 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from backend import app as backend_app
+from fixops.configuration import OverlayConfig
+
+
+def _make_overlay(root: Path) -> OverlayConfig:
+    overlay = OverlayConfig()
+    overlay.allowed_data_roots = (root,)
+    overlay.data = {}
+    overlay.toggles = {}
+    overlay.metadata = {}
+    return overlay
+
+
+def test_create_app_rejects_insecure_allowlisted_root(monkeypatch, tmp_path: Path) -> None:
+    insecure_root = tmp_path / "insecure"
+    insecure_root.mkdir()
+    os.chmod(insecure_root, 0o777)
+
+    overlay = _make_overlay(insecure_root)
+
+    monkeypatch.setattr(backend_app, "load_overlay", lambda: overlay)
+
+    with pytest.raises(PermissionError):
+        backend_app.create_app()

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from fixops.storage import ArtefactArchive
+
+
+@pytest.fixture
+def allowlisted_root(tmp_path: Path) -> Path:
+    root = tmp_path / "allowlisted"
+    root.mkdir()
+    return root
+
+
+def test_archive_rejects_directory_outside_allowlist(tmp_path: Path, allowlisted_root: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with pytest.raises(PermissionError):
+        ArtefactArchive(outside, allowlist=(allowlisted_root,))
+
+
+def test_archive_rejects_world_writable_root(allowlisted_root: Path) -> None:
+    os.chmod(allowlisted_root, 0o777)
+    with pytest.raises(PermissionError):
+        ArtefactArchive(allowlisted_root / "archive", allowlist=(allowlisted_root,))


### PR DESCRIPTION
## Summary
- add an allowlisted path verifier and use it before creating artefact directories in the API, CLI, and archive helper
- extend the FastAPI test double and document hardened deployment expectations for secure storage roots
- add regression tests that ensure insecure directory ownership or permissions raise permission errors

## Testing
- pytest tests/test_storage_security.py tests/test_backend_security.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bb45143083299e1debe9cd0206df