### PR TITLE
Add provider SBOM fallbacks when lib4sbom unavailable

### DIFF
--- a/tests/fixtures/github_dependency_snapshot.json
+++ b/tests/fixtures/github_dependency_snapshot.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "ref": "refs/heads/main",
+  "detectedManifests": {
+    "package.json": {
+      "file": {"sourceLocation": {"path": "services/payment-service/package.json"}},
+      "resolved": {
+        "npm:payments-service@1.0.0": {
+          "name": "payments-service",
+          "version": "1.0.0",
+          "packageUrl": "pkg:npm/payments-service@1.0.0",
+          "licenses": ["MIT"],
+          "publisher": "Payments Team"
+        },
+        "npm:inventory-service@2.3.1": {
+          "name": "inventory-service",
+          "version": "2.3.1",
+          "packageUrl": "pkg:npm/inventory-service@2.3.1",
+          "licenses": ["Apache-2.0"]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/syft_sample_sbom.json
+++ b/tests/fixtures/syft_sample_sbom.json
@@ -1,0 +1,32 @@
+{
+  "artifacts": [
+    {
+      "id": "pkg:apk/alpine/openssl@1.1.1u-r0",
+      "name": "openssl",
+      "version": "1.1.1u-r0",
+      "purl": "pkg:apk/alpine/openssl@1.1.1u-r0",
+      "licenses": [
+        {"value": "OpenSSL"}
+      ],
+      "supplier": {"name": "Alpine"}
+    },
+    {
+      "id": "pkg:apk/alpine/libssl@1.1.1u-r0",
+      "name": "libssl",
+      "version": "1.1.1u-r0",
+      "purl": "pkg:apk/alpine/libssl@1.1.1u-r0",
+      "licenses": ["OpenSSL"]
+    }
+  ],
+  "artifactRelationships": [
+    {
+      "parent": "pkg:apk/alpine/openssl@1.1.1u-r0",
+      "child": "pkg:apk/alpine/libssl@1.1.1u-r0",
+      "type": "contains"
+    }
+  ],
+  "descriptor": {
+    "name": "syft",
+    "version": "0.87.0"
+  }
+}


### PR DESCRIPTION
## Summary
- make lib4sbom optional and add GitHub snapshot/Syft provider parsers as fallbacks
- emit explicit SBOM_PARSER_MISSING errors when lib4sbom is unavailable and no provider matches
- add fixtures and pipeline matching tests that exercise the provider fallbacks and error handling

## Testing
- pytest tests/test_pipeline_matching.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bdd482448329a3eed7e8f2bdb2ad