### PR TITLE
Forward feedback to connectors and persist outcomes

### DIFF
--- a/fixops/feedback.py
+++ b/fixops/feedback.py
@@ -2,22 +2,35 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import time
+from html import escape
 from pathlib import Path
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, MutableMapping, Optional
 
+from fixops.analytics import FeedbackOutcomeStore
 from fixops.configuration import OverlayConfig
+from fixops.connectors import ConfluenceConnector, ConnectorOutcome, JiraConnector
 from fixops.paths import ensure_secure_directory
 
 
 _SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
+logger = logging.getLogger(__name__)
+
+
 class FeedbackRecorder:
     """Persist feedback decisions to a secure directory."""
 
-    def __init__(self, overlay: OverlayConfig):
+    def __init__(
+        self,
+        overlay: OverlayConfig,
+        *,
+        connectors: Optional[Mapping[str, Any]] = None,
+        outcome_store: Optional[FeedbackOutcomeStore] = None,
+    ):
         self.overlay = overlay
         directories = overlay.data_directories
         base_dir = directories.get("feedback_dir") or directories.get("evidence_dir")
@@ -29,6 +42,17 @@ class FeedbackRecorder:
             )
             base_dir = (root / "feedback" / overlay.mode).resolve()
         self.base_dir = ensure_secure_directory(base_dir)
+        self._connectors: Dict[str, Any] = {}
+        if connectors is not None:
+            self._connectors.update(connectors)
+        else:
+            self._connectors.update(
+                {
+                    "jira": JiraConnector(overlay.jira),
+                    "confluence": ConfluenceConnector(overlay.confluence),
+                }
+            )
+        self._outcome_store = outcome_store or FeedbackOutcomeStore(self.base_dir)
 
     def _validate_payload(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
         run_id = payload.get("run_id")
@@ -84,12 +108,110 @@ class FeedbackRecorder:
         line = json.dumps(entry, sort_keys=True)
         with feedback_path.open("a", encoding="utf-8") as handle:
             handle.write(line + "\n")
+        connectors = self._forward_to_connectors(entry)
+        if connectors:
+            try:
+                self._outcome_store.record(entry["run_id"], connectors)
+            except Exception as exc:  # pragma: no cover - persistence should not break flow
+                logger.exception("Failed to persist feedback connector outcomes for run %s", entry["run_id"])
+                connectors.setdefault("_errors", {})
+                connectors["_errors"]["persistence_error"] = str(exc)
         return {
             "run_id": entry["run_id"],
             "path": str(feedback_path),
             "decision": entry["decision"],
             "timestamp": entry["timestamp"],
+            "connectors": connectors,
         }
+
+    def _forward_to_connectors(self, entry: Mapping[str, Any]) -> Dict[str, Dict[str, Any]]:
+        outcomes: Dict[str, Dict[str, Any]] = {}
+        if not self._connectors:
+            return outcomes
+
+        for name, connector in self._connectors.items():
+            try:
+                outcome = self._send_to_connector(name, connector, entry)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Feedback forwarding failed for connector %s", name)
+                outcomes[str(name)] = {"status": "error", "error": str(exc)}
+                continue
+
+            if outcome is None:
+                continue
+            if isinstance(outcome, ConnectorOutcome):
+                outcomes[str(name)] = outcome.to_dict()
+            elif isinstance(outcome, Mapping):
+                data = dict(outcome)
+                data.setdefault("status", data.get("status", "unknown"))
+                outcomes[str(name)] = data
+            else:
+                outcomes[str(name)] = {"status": "unknown", "result": str(outcome)}
+
+        return outcomes
+
+    def _send_to_connector(
+        self,
+        name: str,
+        connector: Any,
+        entry: Mapping[str, Any],
+    ) -> Optional[ConnectorOutcome]:
+        action: MutableMapping[str, Any]
+        decision = entry.get("decision", "")
+        run_id = entry.get("run_id", "")
+        notes = entry.get("notes") or "No reviewer notes provided."
+        submitted_by = entry.get("submitted_by") or "anonymous"
+        tags = entry.get("tags") or []
+        tag_text = ", ".join(tags) if tags else "none"
+        summary = f"Feedback for FixOps run {run_id}: {decision}".strip()
+
+        description_lines = [
+            f"Run ID: {run_id}",
+            f"Decision: {decision}",
+            f"Submitted by: {submitted_by}",
+            f"Tags: {tag_text}",
+            "Notes:",
+            str(notes),
+        ]
+        description = "\n".join(description_lines)
+
+        if name == "jira" and hasattr(connector, "create_issue"):
+            action = {
+                "type": "jira_issue",
+                "summary": summary or f"Feedback for FixOps run {run_id}",
+                "description": description,
+                "labels": list(tags) if isinstance(tags, list) else [],
+                "run_id": run_id,
+            }
+            return connector.create_issue(action)
+
+        if name == "confluence" and hasattr(connector, "create_page"):
+            body = (
+                "<p><strong>Run ID:</strong> {run}</p>"
+                "<p><strong>Decision:</strong> {decision}</p>"
+                "<p><strong>Submitted by:</strong> {submitted}</p>"
+                "<p><strong>Tags:</strong> {tags}</p>"
+                "<p><strong>Notes:</strong><br/>{notes}</p>"
+            ).format(
+                run=escape(str(run_id)),
+                decision=escape(str(decision)),
+                submitted=escape(str(submitted_by)),
+                tags=escape(tag_text),
+                notes=escape(str(notes)),
+            )
+            action = {
+                "type": "confluence_page",
+                "title": summary or f"FixOps Feedback {run_id}",
+                "body": body,
+                "representation": "storage",
+                "metadata": {
+                    "run_id": run_id,
+                    "decision": decision,
+                },
+            }
+            return connector.create_page(action)
+
+        return None
 
 
 __all__ = ["FeedbackRecorder"]

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,8 +1,10 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from fixops.configuration import OverlayConfig
+from fixops.connectors import ConnectorOutcome
 from fixops.feedback import FeedbackRecorder
 
 
@@ -28,8 +30,12 @@ def test_feedback_recorder_writes_entries(tmp_path: Path) -> None:
     assert feedback_file.exists()
     assert entry["run_id"] == "abc123"
     assert entry["decision"] == "accepted"
+    assert entry["connectors"]
+    assert entry["connectors"]["jira"]["status"] in {"skipped", "sent", "failed"}
     content = feedback_file.read_text(encoding="utf-8").strip()
     assert "Reviewed guardrail outcome" in content
+    forwarding_log = tmp_path / "feedback" / "abc123" / "feedback_forwarding.jsonl"
+    assert forwarding_log.exists()
 
 
 def test_feedback_recorder_rejects_path_traversal(tmp_path: Path) -> None:
@@ -47,3 +53,60 @@ def test_feedback_recorder_rejects_path_traversal(tmp_path: Path) -> None:
                 "decision": "rejected",
             }
         )
+
+
+class _StubJira:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create_issue(self, action):  # type: ignore[no-untyped-def]
+        self.calls.append(dict(action))
+        return ConnectorOutcome("sent", {"issue_key": "FIX-101"})
+
+
+class _StubConfluence:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create_page(self, action):  # type: ignore[no-untyped-def]
+        self.calls.append(dict(action))
+        return ConnectorOutcome("sent", {"page_id": "42"})
+
+
+def test_feedback_forwarding_records_connector_outcomes(tmp_path: Path) -> None:
+    overlay = OverlayConfig(
+        data={"feedback_dir": str(tmp_path / "feedback")},
+        toggles={"capture_feedback": True},
+        allowed_data_roots=(tmp_path.resolve(),),
+    )
+    jira = _StubJira()
+    confluence = _StubConfluence()
+    recorder = FeedbackRecorder(
+        overlay,
+        connectors={"jira": jira, "confluence": confluence},
+    )
+
+    entry = recorder.record(
+        {
+            "run_id": "demo456",
+            "decision": "needs_review",
+            "notes": "Escalate for manual triage",
+            "submitted_by": "analyst@example.com",
+            "tags": ["urgent"],
+        }
+    )
+
+    assert jira.calls and confluence.calls
+    jira_action = jira.calls[0]
+    assert jira_action["type"] == "jira_issue"
+    assert "needs_review" in str(jira_action["summary"])
+    assert entry["connectors"]["jira"]["status"] == "sent"
+    assert entry["connectors"]["confluence"]["status"] == "sent"
+
+    log_path = tmp_path / "feedback" / "demo456" / "feedback_forwarding.jsonl"
+    assert log_path.exists()
+    lines = [line for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert lines
+    record = json.loads(lines[-1])
+    assert record["outcomes"]["jira"]["status"] == "sent"
+    assert record["outcomes"]["confluence"]["status"] == "sent"


### PR DESCRIPTION
## Summary
- extend the feedback recorder to forward validated feedback to Jira and Confluence connectors and capture their outcomes
- add a feedback outcome store in ROI analytics to persist connector delivery results alongside feedback artefacts
- expand feedback tests to cover connector forwarding and persistence behaviour

## Testing
- pytest tests/test_feedback.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bdd043d88329a01e0272ccf354f4