### PR TITLE
Add SARIF fallback when snyk converter missing

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -12,7 +12,7 @@ FixOps Demo primarily interacts with two categories of integrations:
 | ----------- | ------- | ---------------- | ----------------------- |
 | `lib4sbom` | Parses SPDX/CycloneDX SBOM documents into a common representation. | `InputNormalizer.load_sbom()` instantiates `SBOMParser`, reads the SBOM string, and extracts packages/relationships/services. | Propagates parser exceptions; the API converts them to HTTP 400 responses. |
 | `cvelib` | Validates CVE/KEV records against the official schema. | `InputNormalizer.load_cve_feed()` calls `CveRecord.validate()` when available. | Missing library downgrades to best-effort ingestion; validation errors are reported in the response payload. |
-| `snyk-to-sarif` | Converts proprietary Snyk JSON payloads into SARIF. | `InputNormalizer.load_sarif()` detects missing `runs` and calls `convert`/`to_sarif` if present. | Absent converter causes non-SARIF payloads to be rejected via `ValueError`, surfaced as HTTP 400. |
+| `snyk-to-sarif` | Converts proprietary Snyk JSON payloads into SARIF. | `InputNormalizer.load_sarif()` detects missing `runs` and calls `convert`/`to_sarif` if present, falling back to embedded SARIF logs when available. | When the converter is absent the service logs actionable guidance and only rejects payloads that cannot be converted, still accepting supported SARIF schemas. |
 | `sarif-om` | Provides typed SARIF models for introspection. | `InputNormalizer.load_sarif()` instantiates `SarifLog` to expose metadata and simplify traversal. | Missing dependency raises a `RuntimeError` during import, signalling a deployment misconfiguration. |
 
 All parsers run synchronously during request handling. Retry logic is unnecessary because failures are

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -1,0 +1,67 @@
+import json
+import logging
+
+import pytest
+
+from backend.normalizers import InputNormalizer
+
+
+@pytest.fixture(autouse=True)
+def _reset_converter(monkeypatch):
+    """Ensure tests control the optional Snyk converter."""
+
+    monkeypatch.setattr("backend.normalizers.snyk_converter", None)
+
+
+def _build_sarif_document():
+    return {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "FallbackScanner"}},
+                "results": [
+                    {
+                        "ruleId": "FBK001",
+                        "level": "warning",
+                        "message": {"text": "Example finding"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "src/app.py"},
+                                    "region": {"startLine": 10},
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_load_sarif_uses_embedded_payload_when_converter_missing():
+    normalizer = InputNormalizer()
+    sarif_document = _build_sarif_document()
+
+    payload = {
+        "ok": True,
+        "sarif": json.dumps(sarif_document),
+    }
+
+    normalized = normalizer.load_sarif(json.dumps(payload))
+
+    assert normalized.metadata["finding_count"] == 1
+    assert normalized.metadata["supported_schema"] is True
+
+
+def test_load_sarif_logs_actionable_error_without_converter(caplog):
+    normalizer = InputNormalizer()
+
+    raw_payload = json.dumps({"issues": [], "ok": False})
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            normalizer.load_sarif(raw_payload)
+
+    assert "snyk-to-sarif" in caplog.text


### PR DESCRIPTION
## Summary
- add a SARIF fallback path that parses embedded logs and reports actionable errors when the optional snyk-to-sarif converter is unavailable
- flag supported SARIF schemas in the metadata and document the improved behaviour
- cover the fallback behaviour with dedicated unit tests

## Testing
- pytest tests/test_normalizers.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bdd8351483298de6906a443b4eb5