### PR TITLE
Add feature matrix aggregation for FixOps pipeline

### DIFF
--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -16,6 +16,7 @@ from fixops.probabilistic import ProbabilisticForecastEngine
 from fixops.ssdlc import SSDLCEvaluator
 from fixops.exploit_signals import ExploitFeedRefresher, ExploitSignalEvaluator
 from fixops.iac import IaCPostureEvaluator
+from fixops.feature_matrix import build_feature_matrix
 from fixops.modules import PipelineContext, execute_custom_modules
 from fixops.tenancy import TenantLifecycleManager
 from fixops.performance import PerformanceSimulator
@@ -547,5 +548,6 @@ class PipelineOrchestrator:
                 "executed": executed_modules,
                 "custom": custom_outcomes,
             }
+            result["feature_matrix"] = build_feature_matrix(result)
 
         return result

--- a/docs/FIXOPS_ADOPTION_GUIDE.md
+++ b/docs/FIXOPS_ADOPTION_GUIDE.md
@@ -1,0 +1,98 @@
+# FixOps Adoption Playbook
+
+FixOps becomes inevitable when organizations exhaust manual controls across regulatory, operational, and AI-driven risk domains. This refreshed playbook turns those breaking points into a cross-functional rollout blueprint that highlights ownership, timing, and measurable success.
+
+## Trigger-to-Action Control Board
+
+| Trigger Area | Leading Indicator | Immediate FixOps Actions | Success Signal | Accountable Lead |
+| --- | --- | --- | --- | --- |
+| Regulatory & Board Escalations | Board escalations, new supervisory guidance, M&A diligence | Launch a 2-week FixOps discovery sprint to map obligations into compliance scorecards and automated evidence packs | Auto-generated audit packets reviewed in the next governance meeting | CISO / Compliance Lead |
+| Pipeline & Triage Overload | Scanner noise >50%, backlog SLA breaches, release freezes | Connect CI/CD, SBOM, and scanner feeds to FixOps context pipeline; enable guardrail-aware triage | 60% reduction in noise, 40% faster remediation within 30 days | DevSecOps / Platform |
+| Audit Evidence & Policy Automation | Manual evidence requests, waiver backlogs, failed control attestations | Codify SSDLC guardrails in FixOps Policy Planner and schedule evidence exports per release train | Zero manual spreadsheet hunts and on-demand auditor packets | Compliance Program Manager |
+| Executive ROI & Telemetry Demands | CFO ROI mandates, enterprise OKR refresh, cost-cut directives | Instrument FixOps ROI dashboards, align KPIs with finance scorecards, publish executive-ready telemetry | Quarterly report shows quantified productivity & risk ROI | Security Operations Lead + FP&A |
+| AI Agent Governance | Agentic AI pilots without controls, regulator inquiries, model prompt incidents | Onboard AI projects into FixOps AI Agent Advisor; apply recommended guardrails and evidence streams | AI guardrails enforced with documented oversight trails | AI Program Owner |
+
+## Persona-Centric Adoption Plays
+
+- **CISO / Compliance Officer**
+  - Secure executive sponsorship by packaging regulatory obligations into FixOps scorecards.
+  - Establish automated evidence runs for the next audit window; share sample bundles with audit partners.
+  - Measure: audit cycle time, number of manual waivers, board satisfaction score.
+
+- **DevSecOps & Platform Engineering**
+  - Prioritize the noisiest pipeline and integrate FixOps correlation services ahead of manual triage queues.
+  - Run canary deployments with guardrail-aware tickets to prove cycle-time gains before scaling.
+  - Measure: deployment wait times, percentage of prioritized findings with context, guardrail adherence rates.
+
+- **Product & Engineering Leaders**
+  - Map FixOps outputs to engineering OKRs so security insights appear inside existing planning cadences.
+  - Partner with program management to automate exception management workflows through FixOps policies.
+  - Measure: time saved per release planning session, escalations avoided, throughput impact.
+
+- **Finance / FP&A Partners**
+  - Co-design ROI dashboards and baseline cost-to-remediate and audit prep labor hours.
+  - Present FixOps impact in QBRs to maintain funding and align on future automation targets.
+  - Measure: labor hours reclaimed, budget variance, risk-adjusted ROI.
+
+## 30/60/90 Day Rollout Plan
+
+- **Days 0–30: Foundation**
+  - Stand up the adoption squad and document the top three triggers causing “cry for help” escalations.
+  - Integrate FixOps with identity, issue tracking, and CI/CD for the highest-risk product line.
+  - Deliver first telemetry snapshot (noise reduction, remediation speed, audit readiness).
+
+- **Days 31–60: Expansion**
+  - Expand guardrail libraries to cover critical policies (e.g., SOC 2, ISO 27001, AI ethics requirements).
+  - Automate evidence bundles per release train; test export workflows with internal audit.
+  - Publish ROI dashboards for finance review and align on quarterly reporting cadence.
+
+- **Days 61–90: Scale & Institutionalize**
+  - Roll FixOps context pipeline across remaining SDLC stages and multi-cloud assets.
+  - Onboard AI workloads into the AI Agent Advisor with defined guardrail tiers.
+  - Formalize continuous improvement rituals (monthly retros, quarterly exec updates).
+
+## Integration Checklist
+
+1. **Source Systems Connected** – CI/CD pipelines, scanner feeds, SBOM repositories, cloud telemetry.
+2. **Policy Packs Enabled** – SOC 2, ISO 27001, internal SSDLC guardrails, AI oversight policies.
+3. **Evidence Automation** – Scheduled exports mapped to compliance calendars and audit asks.
+4. **Workflow Automation** – Guardrail-aware tickets routed to existing planning tools (Jira, Azure DevOps, etc.).
+5. **Analytics & ROI** – Dashboards configured for security leadership, finance partners, and program managers.
+
+## Change Management & Risk Mitigation
+
+- Establish a FixOps champion network inside each delivery tribe to socialize new guardrails.
+- Document a waiver process within FixOps to prevent shadow exceptions.
+- Pair training with telemetry: every enablement session should point to the dashboard that proves value.
+- Maintain a feedback backlog for platform improvements and review it in monthly adoption retrospectives.
+
+## Continuous Measurement
+
+- Track operational KPIs (noise reduction, remediation speed, audit readiness) alongside financial KPIs (labor hours reclaimed, risk-adjusted ROI) and governance KPIs (guardrail coverage, AI oversight completeness).
+- Share a quarterly FixOps adoption scorecard with executives, highlighting wins, upcoming integrations, and remaining risks.
+
+## FixOps Feature Coverage Matrix
+
+| FixOps Capability | Adoption Artifact in This Playbook | Owner Ensuring Delivery | Validation Signal |
+| --- | --- | --- | --- |
+| Context Correlation Pipeline | Trigger-to-Action board (Pipeline & Triage Overload) and 30/60/90 expansion phase | DevSecOps / Platform | Reduction in noise & faster remediation metrics recorded in telemetry snapshot |
+| Automated Evidence Packs | Regulatory trigger actions, Audit Evidence policy automation steps, Integration Checklist #3 | Compliance Lead | Scheduled evidence exports reviewed with audit partners |
+| Adaptive Guardrails & Policy Planner | Persona plays for engineering, 30/60/90 guardrail expansion, Change Management guidance | Product & Engineering Leaders | Guardrail adherence trends on adoption scorecard |
+| ROI & Performance Dashboards | Executive ROI trigger, Finance persona actions, Continuous Measurement | Security Ops + FP&A | Quarterly ROI report with labor hours reclaimed |
+| AI Agent Advisor & Governance | AI Agent trigger, 30/60/90 AI onboarding, Change Management champion network | AI Program Owner | Documented AI guardrail tiers and oversight trails |
+| Integration & Workflow Automation | Integration Checklist items #1, #4 and rollout foundation steps | Adoption Squad / Platform PM | Closed-loop routing of guardrail-aware tickets |
+
+Use this matrix during steering reviews to confirm every flagship FixOps feature is both deployed and measured. When any cell lags, pull the associated playbook actions forward so no capability stalls during rollout.
+
+By aligning triggers, personas, and measurable outcomes, teams transform urgent pain into a structured FixOps rollout—moving from reactive escalations to a durable, audit-ready operating model.
+
+## Feature Validation Snapshot
+
+The automated `test_feature_matrix.py` integration run exercises the full FixOps pipeline with representative design, SBOM, SARIF, and CVE inputs. It confirms the following capabilities execute together without manual intervention:
+
+- **Context & Guardrails** – Context crosswalks, guardrail evaluations, and policy automation workflows all return successful statuses in the same pipeline run.
+- **Evidence & Compliance** – Evidence bundles are generated on disk and mapped to compliance scorecards for audit consumption.
+- **Analytics & Performance** – ROI analytics, performance profiling, and probabilistic forecasting emit non-empty metrics for leadership reporting.
+- **AI, Exploitability, IaC & Tenancy** – AI agent analysis, exploit signal correlation, IaC posture assessment, and tenant lifecycle summaries are produced alongside traditional security modules.
+
+Track this section after each regression cycle to confirm the end-to-end feature surface remains intact as the platform evolves.

--- a/fixops/feature_matrix.py
+++ b/fixops/feature_matrix.py
@@ -1,0 +1,276 @@
+"""Feature matrix aggregation utilities for FixOps pipeline runs."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable, Dict
+
+
+def _as_mapping(value: Any) -> Dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _as_sequence(value: Any) -> list[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return list(value)
+    return []
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _guardrail_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    evaluation = _as_mapping(pipeline_result.get("guardrail_evaluation"))
+    return {
+        "maturity": evaluation.get("maturity"),
+        "highest_detected": evaluation.get("highest_detected"),
+        "severity_counts": _as_mapping(evaluation.get("severity_counts")),
+    }
+
+
+def _context_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    context_summary = _as_mapping(pipeline_result.get("context_summary"))
+    summary = _as_mapping(context_summary.get("summary"))
+    highest_component = _as_mapping(summary.get("highest_component"))
+    playbook = _as_mapping(highest_component.get("playbook"))
+    return {
+        "components_evaluated": _to_int(summary.get("components_evaluated")),
+        "average_score": _to_float(summary.get("average_score")),
+        "top_component": highest_component.get("name"),
+        "top_playbook": playbook.get("name"),
+    }
+
+
+def _onboarding_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    onboarding = _as_mapping(pipeline_result.get("onboarding"))
+    steps = _as_sequence(onboarding.get("steps"))
+    integrations = _as_mapping(onboarding.get("integrations"))
+    return {
+        "mode": onboarding.get("mode"),
+        "step_count": len(steps),
+        "time_to_value_minutes": _to_float(onboarding.get("time_to_value_minutes"), 0.0),
+        "integrations_configured": len(integrations),
+    }
+
+
+def _compliance_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    compliance = _as_mapping(pipeline_result.get("compliance_status"))
+    frameworks = _as_sequence(compliance.get("frameworks"))
+    satisfied = sum(
+        1
+        for framework in frameworks
+        if _as_mapping(framework).get("status") == "satisfied"
+    )
+    return {
+        "framework_count": len(frameworks),
+        "satisfied_frameworks": satisfied,
+        "gap_count": len(_as_sequence(compliance.get("gaps"))),
+    }
+
+
+def _policy_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    policy = _as_mapping(pipeline_result.get("policy_automation"))
+    actions = _as_sequence(policy.get("actions"))
+    execution = _as_mapping(policy.get("execution"))
+    results = _as_sequence(execution.get("results"))
+    delivered = 0
+    for result in results:
+        delivery = _as_mapping(result).get("delivery")
+        if _as_mapping(delivery).get("status") == "sent":
+            delivered += 1
+    return {
+        "action_count": len(actions),
+        "execution_status": execution.get("status"),
+        "results_recorded": len(results),
+        "deliveries_sent": delivered,
+    }
+
+
+def _evidence_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    bundle = _as_mapping(pipeline_result.get("evidence_bundle"))
+    files = _as_mapping(bundle.get("files"))
+    sections = _as_sequence(bundle.get("sections"))
+    return {
+        "bundle_id": bundle.get("bundle_id"),
+        "file_count": len(files),
+        "section_count": len(sections),
+        "compressed": bool(bundle.get("compressed")),
+        "encrypted": bool(bundle.get("encrypted")),
+    }
+
+
+def _analytics_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    analytics = _as_mapping(pipeline_result.get("analytics"))
+    overview = _as_mapping(analytics.get("overview"))
+    insights = _as_sequence(analytics.get("insights"))
+    return {
+        "estimated_value": _to_float(overview.get("estimated_value")),
+        "noise_reduction_percent": _to_float(overview.get("noise_reduction_percent")),
+        "insight_count": len(insights),
+    }
+
+
+def _ai_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    ai_analysis = _as_mapping(pipeline_result.get("ai_agent_analysis"))
+    summary = _as_mapping(ai_analysis.get("summary"))
+    frameworks = summary.get("frameworks_detected")
+    frameworks_list = (
+        list(frameworks)
+        if isinstance(frameworks, Sequence) and not isinstance(frameworks, (str, bytes))
+        else []
+    )
+    return {
+        "components_with_agents": _to_int(summary.get("components_with_agents")),
+        "total_matches": _to_int(summary.get("total_matches")),
+        "frameworks_detected": frameworks_list,
+    }
+
+
+def _exploit_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    exploit = _as_mapping(pipeline_result.get("exploitability_insights"))
+    overview = _as_mapping(exploit.get("overview"))
+    escalations = _as_sequence(exploit.get("escalations"))
+    return {
+        "matched_records": _to_int(overview.get("matched_records")),
+        "signals_configured": _to_int(overview.get("signals_configured")),
+        "escalation_count": len(escalations),
+    }
+
+
+def _probabilistic_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    forecast = _as_mapping(pipeline_result.get("probabilistic_forecast"))
+    metrics = _as_mapping(forecast.get("metrics"))
+    components = _as_sequence(forecast.get("components"))
+    return {
+        "expected_high_or_critical": _to_float(metrics.get("expected_high_or_critical")),
+        "entropy_bits": _to_float(metrics.get("entropy_bits")),
+        "hotspot_count": len(
+            [
+                entry
+                for entry in components
+                if _to_float(_as_mapping(entry).get("escalation_probability")) >= 0.2
+            ]
+        ),
+    }
+
+
+def _ssdlc_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    ssdlc = _as_mapping(pipeline_result.get("ssdlc_assessment"))
+    summary = _as_mapping(ssdlc.get("summary"))
+    recommendations = _as_sequence(summary.get("recommendations"))
+    return {
+        "total_stages": _to_int(summary.get("total_stages")),
+        "gaps": _to_int(summary.get("gaps")),
+        "recommendation_count": len(recommendations),
+    }
+
+
+def _iac_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    iac = _as_mapping(pipeline_result.get("iac_posture"))
+    targets = _as_sequence(iac.get("targets"))
+    unmatched = _as_sequence(iac.get("unmatched_components"))
+    issue_count = 0
+    for target in targets:
+        issue_count += len(_as_sequence(_as_mapping(target).get("artifacts_missing")))
+    return {
+        "target_count": len(targets),
+        "unmatched_components": unmatched,
+        "artifact_gaps": issue_count,
+    }
+
+
+def _tenancy_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    lifecycle = _as_mapping(pipeline_result.get("tenant_lifecycle"))
+    summary = _as_mapping(lifecycle.get("summary"))
+    return {
+        "total_tenants": _to_int(summary.get("total_tenants")),
+        "status_counts": _as_mapping(summary.get("status_counts")),
+        "stage_counts": _as_mapping(summary.get("stage_counts")),
+    }
+
+
+def _performance_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    performance = _as_mapping(pipeline_result.get("performance_profile"))
+    summary = _as_mapping(performance.get("summary"))
+    timeline = _as_sequence(performance.get("timeline"))
+    return {
+        "total_estimated_latency_ms": _to_float(summary.get("total_estimated_latency_ms")),
+        "module_execution_ms": _to_float(summary.get("module_execution_ms")),
+        "timeline_events": len(timeline),
+        "status": summary.get("status"),
+    }
+
+
+def _pricing_metrics(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    pricing = _as_mapping(pipeline_result.get("pricing_summary"))
+    plans = _as_sequence(pricing.get("plans"))
+    return {
+        "plan_count": len(plans),
+    }
+
+
+_MODULE_BUILDERS: Dict[str, Callable[[Mapping[str, Any]], Dict[str, Any]]] = {
+    "guardrails": _guardrail_metrics,
+    "context_engine": _context_metrics,
+    "onboarding": _onboarding_metrics,
+    "compliance": _compliance_metrics,
+    "policy_automation": _policy_metrics,
+    "evidence": _evidence_metrics,
+    "analytics": _analytics_metrics,
+    "ai_agents": _ai_metrics,
+    "exploit_signals": _exploit_metrics,
+    "probabilistic": _probabilistic_metrics,
+    "ssdlc": _ssdlc_metrics,
+    "iac_posture": _iac_metrics,
+    "tenancy": _tenancy_metrics,
+    "performance": _performance_metrics,
+    "pricing": _pricing_metrics,
+}
+
+
+def build_feature_matrix(pipeline_result: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a feature coverage matrix derived from a pipeline run result."""
+
+    modules = _as_mapping(pipeline_result.get("modules"))
+    status_map = _as_mapping(modules.get("status"))
+    execution_order = _as_sequence(modules.get("executed"))
+
+    features: Dict[str, Dict[str, Any]] = {}
+    for name, status in status_map.items():
+        status_text = str(status)
+        available = status_text == "executed"
+        metrics_builder = _MODULE_BUILDERS.get(name)
+        metrics = metrics_builder(pipeline_result) if (metrics_builder and available) else {}
+        features[name] = {
+            "status": status_text,
+            "available": available,
+            "metrics": metrics,
+        }
+
+    executed = [name for name, payload in features.items() if payload["available"]]
+    missing = [name for name, payload in features.items() if not payload["available"]]
+
+    summary = {
+        "features_tracked": len(features),
+        "features_available": len(executed),
+        "features_missing": sorted(missing),
+        "executed_modules": sorted(executed),
+        "execution_order": [str(entry) for entry in execution_order],
+    }
+
+    return {"summary": summary, "features": features}
+
+
+__all__ = ["build_feature_matrix"]

--- a/tests/test_feature_matrix.py
+++ b/tests/test_feature_matrix.py
@@ -1,0 +1,259 @@
+from pathlib import Path
+
+import pytest
+
+from backend.pipeline import PipelineOrchestrator
+from backend.normalizers import (
+    CVERecordSummary,
+    NormalizedCVEFeed,
+    NormalizedSARIF,
+    NormalizedSBOM,
+    SBOMComponent,
+    SarifFinding,
+)
+from fixops.configuration import load_overlay
+
+
+@pytest.mark.parametrize("customer_impact,data_classification,exposure", [
+    ("mission_critical", "pii", "internet"),
+    ("external", "financial", "partner"),
+])
+def test_feature_matrix_alignment(tmp_path, monkeypatch, customer_impact, data_classification, exposure):
+    monkeypatch.setenv("FIXOPS_API_TOKEN", "matrix-token")
+    monkeypatch.setenv("FIXOPS_DATA_ROOT_ALLOWLIST", str(tmp_path))
+
+    overlay = load_overlay()
+
+    overlay.data = {
+        "evidence_dir": str(tmp_path / "evidence" / overlay.mode),
+        "archive_dir": str(tmp_path / "archive" / overlay.mode),
+        "analytics_dir": str(tmp_path / "analytics" / overlay.mode),
+        "automation_dir": str(tmp_path / "automation" / overlay.mode),
+        "feedback_dir": str(tmp_path / "feedback" / overlay.mode),
+        "feeds_dir": str(tmp_path / "feeds" / overlay.mode),
+    }
+    overlay.exploit_signals.setdefault("auto_refresh", {})["enabled"] = False
+    overlay.exploit_signals.get("auto_refresh", {}).setdefault("feeds", [])
+
+    design_dataset = {
+        "columns": [
+            "component",
+            "owner",
+            "customer_impact",
+            "data_classification",
+            "exposure",
+            "notes",
+        ],
+        "rows": [
+            {
+                "component": "payment-service",
+                "owner": "app-team",
+                "customer_impact": customer_impact,
+                "data_classification": data_classification,
+                "exposure": exposure,
+                "notes": "Handles card processing with LangChain agent",
+            },
+            {
+                "component": "notification-service",
+                "owner": "platform",
+                "customer_impact": "internal",
+                "data_classification": "internal",
+                "exposure": "partner",
+                "notes": "Sends transactional messages",
+            },
+        ],
+    }
+
+    sbom = NormalizedSBOM(
+        format="CycloneDX",
+        document={"bomFormat": "CycloneDX", "specVersion": "1.4"},
+        components=[
+            SBOMComponent(name="payment-service", version="1.0.0"),
+            SBOMComponent(name="notification-service", version="2.0.0"),
+        ],
+        relationships=[],
+        services=[],
+        vulnerabilities=[],
+        metadata={"component_count": 2},
+    )
+
+    sarif = NormalizedSARIF(
+        version="2.1.0",
+        schema_uri="https://json.schemastore.org/sarif-2.1.0.json",
+        tool_names=["DemoScanner"],
+        findings=[
+            SarifFinding(
+                rule_id="DEMO001",
+                message="SQL injection risk",
+                level="error",
+                file="services/payment-service/app.py",
+                line=42,
+                raw={
+                    "analysisTarget": {
+                        "uri": "services/payment-service/app.py",
+                        "index": 0,
+                    }
+                },
+            )
+        ],
+        metadata={"finding_count": 1},
+    )
+
+    cve = NormalizedCVEFeed(
+        records=[
+            CVERecordSummary(
+                cve_id="CVE-2024-0001",
+                title="Demo vulnerability",
+                severity="high",
+                exploited=True,
+                raw={
+                    "cvssV3Severity": "HIGH",
+                    "knownExploited": True,
+                    "epss": 0.72,
+                },
+            )
+        ],
+        errors=[],
+        metadata={"record_count": 1},
+    )
+
+    orchestrator = PipelineOrchestrator()
+    result = orchestrator.run(
+        design_dataset=design_dataset,
+        sbom=sbom,
+        sarif=sarif,
+        cve=cve,
+        overlay=overlay,
+    )
+
+    assert result["status"] == "ok"
+    assert len(result["crosswalk"]) == len(design_dataset["rows"])
+    assert result["context_summary"]["summary"]["components_evaluated"] == len(design_dataset["rows"])
+
+    evidence_bundle = result["evidence_bundle"]
+    assert evidence_bundle["files"]
+    for file_path in evidence_bundle["files"].values():
+        path = Path(file_path)
+        assert path.is_file()
+
+    guardrail = result["guardrail_evaluation"]
+    assert guardrail["status"] in {"pass", "warn", "fail"}
+    assert result["policy_automation"]["execution"]["results"]
+
+    analytics = result["analytics"]
+    assert analytics["overview"]["estimated_value"] >= 0
+    performance = result["performance_profile"]
+    assert performance["summary"]["total_estimated_latency_ms"] >= 0
+
+    ai_analysis = result["ai_agent_analysis"]
+    assert ai_analysis["summary"]["components_with_agents"] >= 1
+
+    exploit_summary = result["exploitability_insights"]
+    assert exploit_summary["overview"]["matched_records"] >= 1
+
+    automation_delivery = result["policy_automation"]["execution"]["results"][0]["delivery"]
+    assert automation_delivery["status"] in {"sent", "skipped", "failed"}
+
+    modules = result["modules"]["status"]
+    expected_modules = {
+        "context_engine",
+        "compliance",
+        "policy_automation",
+        "evidence",
+        "analytics",
+        "ai_agents",
+        "exploit_signals",
+        "probabilistic",
+        "iac_posture",
+        "tenancy",
+        "performance",
+    }
+    assert expected_modules.issubset(modules.keys())
+    assert all(modules[name] == "executed" for name in expected_modules)
+
+    assert result["tenant_lifecycle"]["summary"]
+    assert result["probabilistic_forecast"]["metrics"]["expected_high_or_critical"] >= 0
+    assert result["iac_posture"]["targets"]
+
+    matrix = result["feature_matrix"]
+    assert matrix["summary"]["features_available"] >= len(expected_modules)
+    assert not matrix["summary"]["features_missing"]
+    assert set(matrix["summary"]["executed_modules"]) >= expected_modules
+    assert matrix["summary"]["execution_order"] == result["modules"]["executed"]
+
+    guardrail_metrics = matrix["features"]["guardrails"]["metrics"]
+    assert guardrail_metrics["highest_detected"] == guardrail["highest_detected"]
+
+    context_metrics = matrix["features"]["context_engine"]["metrics"]
+    assert (
+        context_metrics["components_evaluated"]
+        == result["context_summary"]["summary"]["components_evaluated"]
+    )
+
+    compliance_metrics = matrix["features"]["compliance"]["metrics"]
+    assert (
+        compliance_metrics["framework_count"]
+        == len(result["compliance_status"]["frameworks"])
+    )
+
+    policy_metrics = matrix["features"]["policy_automation"]["metrics"]
+    assert policy_metrics["action_count"] == len(result["policy_automation"]["actions"])
+    assert (
+        policy_metrics["results_recorded"]
+        == len(result["policy_automation"]["execution"]["results"])
+    )
+
+    evidence_metrics = matrix["features"]["evidence"]["metrics"]
+    assert evidence_metrics["file_count"] >= len(evidence_bundle["files"])
+    assert evidence_metrics["section_count"] == len(evidence_bundle["sections"])
+
+    analytics_metrics = matrix["features"]["analytics"]["metrics"]
+    assert (
+        analytics_metrics["estimated_value"]
+        == analytics["overview"]["estimated_value"]
+    )
+
+    ai_metrics = matrix["features"]["ai_agents"]["metrics"]
+    assert (
+        ai_metrics["components_with_agents"]
+        == ai_analysis["summary"]["components_with_agents"]
+    )
+
+    exploit_metrics = matrix["features"]["exploit_signals"]["metrics"]
+    assert (
+        exploit_metrics["matched_records"]
+        == exploit_summary["overview"]["matched_records"]
+    )
+
+    probabilistic_metrics = matrix["features"]["probabilistic"]["metrics"]
+    assert (
+        probabilistic_metrics["expected_high_or_critical"]
+        == result["probabilistic_forecast"]["metrics"]["expected_high_or_critical"]
+    )
+
+    ssdlc_metrics = matrix["features"]["ssdlc"]["metrics"]
+    assert (
+        ssdlc_metrics["total_stages"]
+        == result["ssdlc_assessment"]["summary"]["total_stages"]
+    )
+
+    iac_metrics = matrix["features"]["iac_posture"]["metrics"]
+    assert iac_metrics["target_count"] == len(result["iac_posture"]["targets"])
+
+    tenancy_metrics = matrix["features"]["tenancy"]["metrics"]
+    assert (
+        tenancy_metrics["total_tenants"]
+        == result["tenant_lifecycle"]["summary"]["total_tenants"]
+    )
+
+    performance_metrics = matrix["features"]["performance"]["metrics"]
+    assert (
+        performance_metrics["total_estimated_latency_ms"]
+        == performance["summary"]["total_estimated_latency_ms"]
+    )
+
+    onboarding_metrics = matrix["features"]["onboarding"]["metrics"]
+    assert onboarding_metrics["step_count"] == len(result["onboarding"]["steps"])
+
+    pricing_metrics = matrix["features"]["pricing"]["metrics"]
+    assert pricing_metrics["plan_count"] == len(result["pricing_summary"]["plans"])


### PR DESCRIPTION
## Summary
- add a feature matrix builder that consolidates module metrics and availability across the FixOps pipeline
- expose the aggregated feature matrix from the pipeline orchestrator so downstream consumers can inspect coverage
- extend the feature matrix integration test to validate module metrics and execution order across all major capabilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e23c313bb88329bea7ec4ef96f5206