### PR TITLE
Refactor enterprise stack to use ChatGPT for LLM features

### DIFF
--- a/fixops-blended-enterprise/deploy-bank.sh
+++ b/fixops-blended-enterprise/deploy-bank.sh
@@ -143,7 +143,7 @@ async def test():
     await decision_engine.initialize()
     print('✅ Decision Engine initialized')
     print(f'   Mode: {'DEMO' if decision_engine.demo_mode else 'PRODUCTION'}')
-    print(f'   LLM Available: {decision_engine.emergent_client is not None}')
+    print(f'   LLM Available: {decision_engine.chatgpt_client is not None}')
 
 asyncio.run(test())
 "

--- a/fixops-blended-enterprise/frontend/src/pages/CommandCenter.jsx
+++ b/fixops-blended-enterprise/frontend/src/pages/CommandCenter.jsx
@@ -284,7 +284,7 @@ function CommandCenter() {
                   status: isDemo ? 'DEMO' : (operationalState.productionRequirements?.component_status?.llm_consensus?.status === 'READY' ? 'OPERATIONAL' : 'NEEDS_KEYS'), 
                   health: 98, 
                   color: isDemo ? '#f59e0b' : '#10b981',
-                  required: isDemo ? null : 'EMERGENT_LLM_KEY'
+                  required: isDemo ? null : 'OPENAI_API_KEY'
                 },
                 { 
                   component: 'Policy Engine', 

--- a/fixops-blended-enterprise/frontend/src/pages/EnhancedDashboard.jsx
+++ b/fixops-blended-enterprise/frontend/src/pages/EnhancedDashboard.jsx
@@ -77,7 +77,7 @@ function EnhancedDashboard() {
   }
 
   const getLLMIcon = (provider) => {
-    const icons = { emergent_gpt5: '🧠', openai_gpt4: '🤖', anthropic_claude: '🧮', google_gemini: '💎', specialized_cyber: '🛡️' }
+    const icons = { openai_chatgpt: '🧠', openai_gpt4: '🤖', anthropic_claude: '🧮', google_gemini: '💎', specialized_cyber: '🛡️' }
     return icons[provider] || '🤖'
   }
 

--- a/fixops-blended-enterprise/requirements.txt
+++ b/fixops-blended-enterprise/requirements.txt
@@ -44,7 +44,6 @@ dnspython==2.8.0
 ecdsa==0.19.1
 elementpath==5.0.4
 email-validator==2.3.0
-emergentintegrations==0.1.0
 fastapi==0.110.1
 fastjsonschema==2.21.2
 fastuuid==0.13.5

--- a/fixops-blended-enterprise/src/api/v1/decisions.py
+++ b/fixops-blended-enterprise/src/api/v1/decisions.py
@@ -172,9 +172,9 @@ async def get_core_components_status(
             
             # Real LLM integration status
             components["llm_rag"] = {
-                "status": "production_active" if decision_engine.emergent_client else "not_configured",
-                "model": "gpt-5" if decision_engine.emergent_client else "not_available",
-                "integration_type": "Emergent LLM"
+                "status": "production_active" if decision_engine.chatgpt_client else "not_configured",
+                "model": "ChatGPT" if decision_engine.chatgpt_client else "not_available",
+                "integration_type": "OpenAI ChatGPT"
             }
             
             # Real consensus checker status

--- a/fixops-blended-enterprise/src/api/v1/processing_layer.py
+++ b/fixops-blended-enterprise/src/api/v1/processing_layer.py
@@ -68,7 +68,7 @@ async def get_processing_layer_status():
                 "ctinexus_approach": "LLM-based entity extraction with in-context learning",
                 "awesome_llm4cybersecurity": "Cybersecurity-specialized LLM models and prompts",
                 "networkx": "Graph construction and analysis",
-                "emergent_llm": "Real LLM integration for explanations"
+                "chatgpt_llm": "Real ChatGPT integration for explanations"
             }
         }
     except Exception as e:

--- a/fixops-blended-enterprise/src/api/v1/production_readiness.py
+++ b/fixops-blended-enterprise/src/api/v1/production_readiness.py
@@ -54,14 +54,14 @@ async def get_production_readiness():
             readiness_status["missing_requirements"].append("CONFLUENCE_CREDENTIALS")
         
         # LLM Integration Readiness
-        llm_ready = bool(settings.EMERGENT_LLM_KEY or (settings.OPENAI_API_KEY and settings.ANTHROPIC_API_KEY))
+        llm_ready = bool(settings.primary_llm_api_key)
         readiness_status["component_status"]["llm_consensus"] = {
             "status": "READY" if llm_ready else "NEEDS_KEYS",
-            "required": "LLM_API_KEYS" if not llm_ready else None,
-            "description": "Emergent LLM or OpenAI+Anthropic keys" if not llm_ready else "Multi-LLM consensus active"
+            "required": "OPENAI_API_KEY" if not llm_ready else None,
+            "description": "OpenAI API key for ChatGPT" if not llm_ready else "ChatGPT consensus active"
         }
         if not llm_ready:
-            readiness_status["missing_requirements"].append("LLM_API_KEYS")
+            readiness_status["missing_requirements"].append("OPENAI_API_KEY")
         
         # Policy Engine Readiness (OPA Server)
         opa_ready = False  # Assume OPA server not running by default
@@ -97,7 +97,7 @@ async def get_production_readiness():
         # Quick setup guide
         readiness_status["quick_setup"] = {
             "priority_1": "Set DEMO_MODE=false in environment",
-            "priority_2": "Configure EMERGENT_LLM_KEY for AI consensus", 
+            "priority_2": "Configure OPENAI_API_KEY for ChatGPT consensus",
             "priority_3": "Setup OPA server for policy evaluation",
             "priority_4": "Configure Jira/Confluence for business context",
             "priority_5": "Setup pgvector for vector database"
@@ -118,10 +118,10 @@ async def get_production_requirements():
     return {
         "status": "success",
         "requirements": {
-            "EMERGENT_LLM_KEY": {
-                "component": "Multi-LLM Consensus",
-                "description": "API key for GPT-5, Claude, Gemini consensus analysis",
-                "setup": "Get key from Emergent platform",
+            "OPENAI_API_KEY": {
+                "component": "ChatGPT Consensus",
+                "description": "OpenAI API key powering ChatGPT-based analysis",
+                "setup": "Create an API key in the OpenAI console",
                 "priority": "HIGH"
             },
             "OPA_SERVER": {

--- a/fixops-blended-enterprise/src/config/settings.py
+++ b/fixops-blended-enterprise/src/config/settings.py
@@ -122,7 +122,13 @@ class Settings(BaseSettings):
     LLM_MAX_RETRIES: int = Field(default=3)
     LLM_CONSENSUS_THRESHOLD: float = Field(default=0.75)
     ENABLE_MULTI_LLM: bool = Field(default=True)
-    
+
+    @property
+    def primary_llm_api_key(self) -> Optional[str]:
+        """Return the preferred API key for ChatGPT-backed features."""
+
+        return self.OPENAI_API_KEY or self.EMERGENT_LLM_KEY
+
     @field_validator("CORS_ORIGINS", "ALLOWED_HOSTS", mode="before")
     @classmethod
     def parse_list_fields(cls, v):

--- a/fixops-blended-enterprise/src/services/chatgpt_client.py
+++ b/fixops-blended-enterprise/src/services/chatgpt_client.py
@@ -1,0 +1,171 @@
+"""Utility wrappers around the OpenAI ChatGPT API used across the enterprise stack.
+
+The previous implementation relied on the proprietary ``emergentintegrations``
+package.  Those classes exposed a very small surface area that the rest of the
+codebase depended on (``generate_text`` for completions and ``LlmChat`` style
+helpers for conversational prompts).  To keep the rest of the code stable we
+re-implement the required behaviour with the official OpenAI Python SDK while
+mirroring the minimal interface expected by existing services.
+
+The helpers in this module intentionally avoid pulling in optional dependencies
+at import time.  They only raise clear, actionable errors when the OpenAI SDK is
+unavailable or an API key has not been provided.  This keeps the demo workflow
+usable in environments without network access, while still providing rich
+ChatGPT-backed analysis when an ``OPENAI_API_KEY`` (or legacy
+``EMERGENT_LLM_KEY``) is present.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import structlog
+
+from src.config.settings import get_settings
+
+try:  # pragma: no cover - import guarded for minimal environments
+    from openai import AsyncOpenAI
+except Exception:  # pragma: no cover - fallback when OpenAI SDK missing
+    AsyncOpenAI = None  # type: ignore[assignment]
+
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class UserMessage:
+    """Light-weight message container mirroring ``emergentintegrations``."""
+
+    text: str
+
+
+class ChatGPTClient:
+    """Thin asynchronous wrapper around the ChatGPT responses endpoint."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str = "gpt-4o-mini",
+        max_tokens: int = 800,
+        temperature: float = 0.3,
+    ) -> None:
+        if AsyncOpenAI is None:  # pragma: no cover - handled in minimal envs
+            raise RuntimeError(
+                "openai package is not installed. Install 'openai' to enable ChatGPT integrations."
+            )
+
+        self._client = AsyncOpenAI(api_key=api_key)
+        self._model = model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+
+    async def generate_text(
+        self,
+        *,
+        prompt: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        system_message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Generate a completion using ChatGPT and return a dict compatible with the legacy client."""
+
+        messages = []
+        if system_message:
+            messages.append({"role": "system", "content": system_message})
+        messages.append({"role": "user", "content": prompt})
+
+        try:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=messages,
+                max_tokens=max_tokens or self._max_tokens,
+                temperature=temperature if temperature is not None else self._temperature,
+            )
+        except Exception as exc:  # pragma: no cover - network/runtime errors
+            logger.error("ChatGPT completion failed", error=str(exc))
+            raise
+
+        content = ""
+        if response.choices:
+            content = (response.choices[0].message.content or "").strip()
+
+        usage = getattr(response, "usage", None)
+        usage_payload: Optional[Dict[str, Any]] = None
+        if usage is not None:
+            usage_payload = {
+                "prompt_tokens": getattr(usage, "prompt_tokens", None),
+                "completion_tokens": getattr(usage, "completion_tokens", None),
+                "total_tokens": getattr(usage, "total_tokens", None),
+            }
+
+        return {
+            "content": content,
+            "model": getattr(response, "model", self._model),
+            "usage": usage_payload,
+        }
+
+
+class ChatGPTChatSession:
+    """Drop-in replacement for the ``LlmChat`` helper used by policy/correlation engines."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        system_message: Optional[str] = None,
+        session_id: Optional[str] = None,  # session id kept for API compatibility
+        model: str = "gpt-4o-mini",
+        max_tokens: int = 800,
+        temperature: float = 0.3,
+    ) -> None:
+        self._model = model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._api_key = api_key
+        self._client = ChatGPTClient(
+            api_key,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        self._system_message = system_message
+        self._session_id = session_id
+
+    def with_model(self, provider: str, model: str) -> "ChatGPTChatSession":
+        """Mimic the fluent interface exposed by ``LlmChat``."""
+
+        if provider.lower() != "openai":
+            logger.warning("ChatGPTChatSession only supports OpenAI provider", provider=provider)
+
+        # Re-create the underlying client with the new model to mirror the original behaviour.
+        settings = get_settings()
+        api_key = settings.primary_llm_api_key or self._api_key
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY is required for ChatGPTChatSession")
+
+        self._model = model
+        self._client = ChatGPTClient(
+            api_key,
+            model=model,
+            max_tokens=self._max_tokens,
+            temperature=self._temperature,
+        )
+        self._api_key = api_key
+        return self
+
+    async def send_message(self, message: UserMessage) -> str:
+        response = await self._client.generate_text(
+            prompt=message.text,
+            system_message=self._system_message,
+        )
+        return response.get("content", "")
+
+
+def get_primary_llm_api_key() -> Optional[str]:
+    """Helper used by services to fetch the preferred ChatGPT API key."""
+
+    settings = get_settings()
+    return settings.primary_llm_api_key
+

--- a/fixops-blended-enterprise/src/services/policy_engine.py
+++ b/fixops-blended-enterprise/src/services/policy_engine.py
@@ -3,7 +3,6 @@ FixOps Policy Engine - High-performance policy evaluation with OPA/Rego support
 Enterprise-grade decision automation with 299μs hot path performance and AI-powered insights
 """
 
-import os
 import asyncio
 import time
 import json
@@ -16,8 +15,7 @@ import structlog
 from sqlalchemy import select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from dotenv import load_dotenv
-from emergentintegrations.llm.chat import LlmChat, UserMessage
-
+from src.services.chatgpt_client import ChatGPTChatSession, UserMessage, get_primary_llm_api_key
 from src.db.session import DatabaseManager
 from src.models.security_sqlite import PolicyRule, PolicyDecisionLog, SecurityFinding, Service
 from src.services.cache_service import CacheService
@@ -90,9 +88,9 @@ class PolicyEngine:
     def _initialize_llm(self):
         """Initialize LLM for advanced policy analysis"""
         try:
-            api_key = os.getenv('EMERGENT_LLM_KEY')
+            api_key = get_primary_llm_api_key()
             if api_key:
-                self.llm_chat = LlmChat(
+                self.llm_chat = ChatGPTChatSession(
                     api_key=api_key,
                     session_id="policy_engine_session",
                     system_message="""You are an expert security policy analyst specialized in DevSecOps governance and compliance.
@@ -101,16 +99,18 @@ class PolicyEngine:
                     2. Compliance mapping (NIST SSDF, SOC2, PCI DSS)
                     3. Business impact analysis
                     4. Remediation prioritization guidance
-                    
-                    Always provide structured, compliance-focused analysis that helps organizations make informed security decisions."""
-                ).with_model("openai", "gpt-5")
-                
-                logger.info("LLM policy engine initialized successfully with gpt-5")
+
+                    Always provide structured, compliance-focused analysis that helps organizations make informed security decisions.""",
+                    model="gpt-4o-mini",
+                    max_tokens=700,
+                    temperature=0.2,
+                )
+                logger.info("LLM policy engine initialized successfully with ChatGPT")
             else:
-                logger.warning("No EMERGENT_LLM_KEY found, using rule-based policy evaluation only")
-                
+                logger.warning("No ChatGPT API key found, using rule-based policy evaluation only")
+
         except Exception as e:
-            logger.error(f"Failed to initialize LLM: {str(e)}")
+            logger.error(f"Failed to initialize ChatGPT policy helper: {str(e)}")
             self.llm_chat = None
         
     async def evaluate_policy(self, context: PolicyContext) -> PolicyEvaluationResult:

--- a/frontend-akido-public/src/pages/CommandCenter.jsx
+++ b/frontend-akido-public/src/pages/CommandCenter.jsx
@@ -284,7 +284,7 @@ function CommandCenter() {
                   status: isDemo ? 'DEMO' : (operationalState.productionRequirements?.component_status?.llm_consensus?.status === 'READY' ? 'OPERATIONAL' : 'NEEDS_KEYS'), 
                   health: 98, 
                   color: isDemo ? '#f59e0b' : '#10b981',
-                  required: isDemo ? null : 'EMERGENT_LLM_KEY'
+                  required: isDemo ? null : 'OPENAI_API_KEY'
                 },
                 { 
                   component: 'Policy Engine', 


### PR DESCRIPTION
## Summary
- add a reusable ChatGPT client and prefer OPENAI_API_KEY as the primary LLM credential
- update the decision, policy, correlation, knowledge graph, and explanation services to invoke ChatGPT instead of the Emergent SDK
- refresh API readiness/status endpoints and frontend displays to reflect the new ChatGPT integration requirements

## Testing
- python -m compileall fixops-blended-enterprise/src/services fixops-blended-enterprise/src/api fixops-blended-enterprise/src/config


------
https://chatgpt.com/codex/tasks/task_e_68e372f6cd848329a42ccbf4fbbd692e