### PR TITLE
Fix Azure Key Vault signing invocation

### DIFF
--- a/fixops-blended-enterprise/src/utils/crypto.py
+++ b/fixops-blended-enterprise/src/utils/crypto.py
@@ -364,7 +364,10 @@ class AzureKeyVaultProvider:
         self._refresh_key_material()
 
     def sign(self, payload: bytes) -> bytes:
-        response = self._crypto_client.sign(payload)  # type: ignore[call-arg]
+        response = self._crypto_client.sign(  # type: ignore[call-arg]
+            self._signature_algorithm,
+            payload,
+        )
         signature = _extract_signature(response)
         if signature is None:
             raise RuntimeError("Azure Key Vault did not return a signature")

--- a/tests/test_key_management.py
+++ b/tests/test_key_management.py
@@ -147,7 +147,8 @@ class StubAzureCryptoClient:
     def __init__(self, key_client: StubAzureKeyClient) -> None:
         self._key_client = key_client
 
-    def sign(self, payload: bytes):  # pragma: no cover - exercised via provider
+    def sign(self, algorithm: str, payload: bytes):  # pragma: no cover - exercised via provider
+        assert algorithm == self.default_algorithm
         signature = self._key_client.private_key().sign(
             payload,
             padding.PKCS1v15(),


### PR DESCRIPTION
## Summary
- ensure the Azure Key Vault provider passes its configured signature algorithm to the cryptography client
- update the Azure crypto client stub in the key management tests to reflect the production call signature

## Testing
- pytest tests/test_key_management.py

------
https://chatgpt.com/codex/tasks/task_e_68e5825b47688329bdb5170d2a202c71