### PR TITLE
Demo I/O contract: unified ingest, canonical outputs, IDs, signing, compliance rollups, marketplace, scripted demo

### DIFF
--- a/fixops-blended-enterprise/src/api/v1/__init__.py
+++ b/fixops-blended-enterprise/src/api/v1/__init__.py
@@ -2,11 +2,12 @@
 
 from fastapi import APIRouter
 
-from . import cicd, evidence
+from . import artefacts, cicd, evidence
 
 router = APIRouter()
 router.include_router(cicd.router, prefix="/cicd")
 router.include_router(evidence.router, prefix="/evidence")
+router.include_router(artefacts.router, prefix="/artefacts")
 
 __all__ = ["router"]
 

--- a/fixops-blended-enterprise/src/api/v1/artefacts.py
+++ b/fixops-blended-enterprise/src/api/v1/artefacts.py
@@ -1,0 +1,105 @@
+"""Unified artefact ingestion endpoint."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from pydantic import BaseModel, Field
+
+from src.api.dependencies import authenticate
+from src.services import run_registry
+from src.services.id_allocator import ensure_ids
+
+router = APIRouter(tags=["artefacts"])
+
+
+class ArtefactSubmission(BaseModel):
+    type: str = Field(min_length=1)
+    payload: Dict[str, Any] | None = None
+    app_id: str | None = None
+    run_id: str | None = None
+
+
+class ArtefactResponse(BaseModel):
+    app_id: str
+    run_id: str
+    stored_as: str
+
+
+_INPUT_FILE_MAP: Dict[str, str] = {
+    "requirements": "requirements-input.json",
+    "design": "design-input.json",
+    "sbom": "sbom.json",
+    "sarif": "scanner.sarif",
+    "tfplan": "tfplan.json",
+    "ops": "ops-telemetry.json",
+    "tests": "tests-input.json",
+    "decision": "decision-input.json",
+}
+
+Processor = Callable[[Mapping[str, Any], run_registry.RunContext], None]
+
+
+def _resolve_context(
+    submission: ArtefactSubmission,
+    artefact_type: str,
+    payload: Mapping[str, Any],
+) -> run_registry.RunContext:
+    if submission.run_id:
+        try:
+            return run_registry.reopen_run(submission.app_id, submission.run_id)
+        except FileNotFoundError as exc:  # pragma: no cover - validated through API tests
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found") from exc
+    app_hint = submission.app_id
+    if artefact_type == "design":
+        app_hint = str(payload.get("app_id") or app_hint)
+    return run_registry.resolve_run(app_hint)
+
+
+def _process_design(payload: Mapping[str, Any], context: run_registry.RunContext) -> None:
+    manifest = dict(payload)
+    manifest["design_risk_score"] = _design_risk_score(payload)
+    context.write_output("design.manifest.json", manifest)
+
+
+def _design_risk_score(payload: Mapping[str, Any]) -> float:
+    components = payload.get("components") if isinstance(payload, Mapping) else []
+    score = 0.5
+    if isinstance(components, list):
+        if any(str(item.get("exposure")).lower() == "internet" for item in components if isinstance(item, Mapping)):
+            score += 0.2
+        if any(bool(item.get("pii")) for item in components if isinstance(item, Mapping)):
+            score += 0.08
+    return round(min(score, 0.99), 2)
+
+
+_PROCESSORS: Dict[str, Processor] = {
+    "design": _process_design,
+}
+
+
+@router.post("", response_model=ArtefactResponse, status_code=status.HTTP_201_CREATED)
+async def submit_artefact(
+    submission: ArtefactSubmission,
+    _: None = Depends(authenticate),
+) -> ArtefactResponse:
+    artefact_type = submission.type.lower()
+    if artefact_type not in _INPUT_FILE_MAP:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported artefact type")
+
+    payload: Mapping[str, Any] | Dict[str, Any] = submission.payload or {}
+    if artefact_type == "design":
+        if not isinstance(payload, Mapping):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Design payload must be an object")
+        payload = ensure_ids(payload)
+
+    context = _resolve_context(submission, artefact_type, payload if isinstance(payload, Mapping) else {})
+    filename = _INPUT_FILE_MAP[artefact_type]
+    stored_path = context.save_input(filename, payload)
+    processor = _PROCESSORS.get(artefact_type)
+    if processor and isinstance(payload, Mapping):
+        processor(payload, context)
+    relative = stored_path.relative_to(context.run_path)
+    return ArtefactResponse(app_id=context.app_id, run_id=context.run_id, stored_as=str(relative))

--- a/fixops-blended-enterprise/src/services/__init__.py
+++ b/fixops-blended-enterprise/src/services/__init__.py
@@ -1,0 +1,7 @@
+"""Service exports for FixOps blended backend."""
+
+from __future__ import annotations
+
+from .run_registry import RunContext, reopen_run, resolve_run
+
+__all__ = ["RunContext", "resolve_run", "reopen_run"]

--- a/fixops-blended-enterprise/src/services/id_allocator.py
+++ b/fixops-blended-enterprise/src/services/id_allocator.py
@@ -1,0 +1,43 @@
+"""Helpers for minting deterministic application and component identifiers."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from typing import Any, Dict, Mapping, MutableMapping
+
+_APP_MIN = 1000
+_APP_RANGE = 9000
+
+
+def ensure_ids(design_document: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a copy of the design document with guaranteed identifiers."""
+
+    normalized = copy.deepcopy(dict(design_document))
+    app_name = str(normalized.get("app_name") or "app")
+    app_id = str(normalized.get("app_id") or _mint_app_id(app_name))
+    normalized["app_id"] = app_id
+
+    components = normalized.get("components")
+    if isinstance(components, list):
+        for component in components:
+            if isinstance(component, MutableMapping):
+                name = str(component.get("name") or "component")
+                component.setdefault("component_id", _mint_component_id(name))
+    return normalized
+
+
+def _mint_app_id(app_name: str) -> str:
+    digest = hashlib.sha1(app_name.encode("utf-8")).hexdigest()
+    number = int(digest, 16) % _APP_RANGE + _APP_MIN
+    return f"APP-{number:04d}"
+
+
+def _mint_component_id(name: str) -> str:
+    cleaned = [ch.lower() if ch.isalnum() else "-" for ch in name]
+    token = "".join(cleaned).strip("-") or "component"
+    stem = token.split("-")[0] or "component"
+    return f"C-{stem.lower()}"
+
+
+__all__ = ["ensure_ids"]

--- a/fixops-blended-enterprise/src/services/run_registry.py
+++ b/fixops-blended-enterprise/src/services/run_registry.py
@@ -1,0 +1,110 @@
+"""Run registry for organising per-run artefacts."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+ARTEFACTS_ROOT = Path("artefacts")
+
+_CANONICAL_OUTPUTS: set[str] = {
+    "requirements.json",
+    "design.manifest.json",
+    "build.report.json",
+    "test.report.json",
+    "deploy.manifest.json",
+    "operate.snapshot.json",
+    "decision.json",
+}
+
+
+@dataclass(slots=True)
+class RunContext:
+    """Represents a materialised run folder for an application."""
+
+    app_id: str
+    run_id: str
+    root: Path
+
+    @property
+    def run_path(self) -> Path:
+        return self.root / self.app_id / self.run_id
+
+    @property
+    def inputs_dir(self) -> Path:
+        return self.run_path / "inputs"
+
+    @property
+    def outputs_dir(self) -> Path:
+        return self.run_path / "outputs"
+
+    @property
+    def signed_outputs_dir(self) -> Path:
+        return self.outputs_dir / "signed"
+
+    def save_input(self, name: str, payload: bytes | bytearray | Mapping[str, Any] | Iterable[Any] | str) -> Path:
+        """Persist an input payload beneath the run's inputs directory."""
+
+        target = self.inputs_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(payload, (bytes, bytearray)):
+            target.write_bytes(bytes(payload))
+        elif isinstance(payload, Mapping) or isinstance(payload, Iterable) and not isinstance(payload, (str, bytes, bytearray)):
+            # Treat mapping or iterable structures as JSON
+            target.write_text(_json_dumps(payload))
+        else:
+            target.write_text(str(payload))
+        return target
+
+    def write_output(self, name: str, document: Mapping[str, Any] | Iterable[Any]) -> Path:
+        """Persist a canonical output document and return the file path."""
+
+        if name not in _CANONICAL_OUTPUTS:
+            raise ValueError(f"Unsupported output name: {name}")
+        target = self.outputs_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_json_dumps(document))
+        return target
+
+
+def resolve_run(app_id: str | None) -> RunContext:
+    """Resolve or create the run context for the provided application identifier."""
+
+    normalised_app = _normalise_app_id(app_id)
+    run_id = _dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    root = ARTEFACTS_ROOT
+    run_dir = root / normalised_app / run_id
+    _prepare_directories(run_dir)
+    return RunContext(app_id=normalised_app, run_id=run_id, root=root)
+
+
+def _normalise_app_id(app_id: str | None) -> str:
+    if not app_id:
+        return "APP-UNKNOWN"
+    candidate = app_id.strip() or "APP-UNKNOWN"
+    safe = [ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in candidate]
+    return "".join(safe)
+
+
+def _json_dumps(data: Mapping[str, Any] | Iterable[Any]) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def reopen_run(app_id: str | None, run_id: str) -> RunContext:
+    """Return a run context for an existing run identifier."""
+
+    normalised_app = _normalise_app_id(app_id)
+    root = ARTEFACTS_ROOT
+    run_dir = root / normalised_app / run_id
+    if not run_dir.exists():
+        raise FileNotFoundError(run_dir)
+    _prepare_directories(run_dir)
+    return RunContext(app_id=normalised_app, run_id=run_id, root=root)
+
+
+def _prepare_directories(run_dir: Path) -> None:
+    (run_dir / "inputs").mkdir(parents=True, exist_ok=True)
+    (run_dir / "outputs" / "signed").mkdir(parents=True, exist_ok=True)

--- a/tests/test_api_artefacts.py
+++ b/tests/test_api_artefacts.py
@@ -1,0 +1,83 @@
+"""API tests for unified artefact ingestion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from src.main import create_app
+from src.services import run_registry
+
+
+def _client(monkeypatch, tmp_path: Path) -> TestClient:
+    monkeypatch.setattr(run_registry, "ARTEFACTS_ROOT", tmp_path)
+    app = create_app()
+    return TestClient(app)
+
+
+def test_submit_requirements_payload(monkeypatch, tmp_path: Path) -> None:
+    client = _client(monkeypatch, tmp_path)
+    response = client.post(
+        "/api/v1/artefacts",
+        json={"type": "requirements", "payload": {"hello": "world"}, "app_id": "APP-999"},
+        headers={"Authorization": "Bearer local-dev-key"},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["app_id"] == "APP-999"
+    stored = Path(tmp_path) / body["app_id"] / body["run_id"] / body["stored_as"]
+    assert stored.exists()
+    assert stored.read_text().strip().startswith("{")
+
+
+def test_submit_with_unknown_type(monkeypatch, tmp_path: Path) -> None:
+    client = _client(monkeypatch, tmp_path)
+    response = client.post(
+        "/api/v1/artefacts",
+        json={"type": "unknown", "payload": {}},
+        headers={"Authorization": "Bearer local-dev-key"},
+    )
+    assert response.status_code == 400
+
+
+def test_submit_reuses_existing_run(monkeypatch, tmp_path: Path) -> None:
+    client = _client(monkeypatch, tmp_path)
+    first = client.post(
+        "/api/v1/artefacts",
+        json={"type": "design", "payload": {"components": []}, "app_id": "APP-101"},
+        headers={"Authorization": "Bearer local-dev-key"},
+    )
+    run_id = first.json()["run_id"]
+    second = client.post(
+        "/api/v1/artefacts",
+        json={"type": "sbom", "payload": {"components": []}, "run_id": run_id, "app_id": "APP-101"},
+        headers={"Authorization": "Bearer local-dev-key"},
+    )
+    assert second.status_code == 201
+    assert second.json()["run_id"] == run_id
+
+
+def test_design_submission_generates_manifest(monkeypatch, tmp_path: Path) -> None:
+    client = _client(monkeypatch, tmp_path)
+    payload = {
+        "app_name": "life-claims-portal",
+        "components": [
+            {"name": "login-ui", "tier": "tier-0", "exposure": "internet", "pii": True},
+            {"name": "claims-core", "tier": "tier-0", "exposure": "internal", "pii": True},
+        ],
+    }
+    response = client.post(
+        "/api/v1/artefacts",
+        json={"type": "design", "payload": payload},
+        headers={"Authorization": "Bearer local-dev-key"},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    outputs_dir = Path(tmp_path) / body["app_id"] / body["run_id"] / "outputs"
+    manifest_path = outputs_dir / "design.manifest.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["components"][0]["component_id"].startswith("C-")
+    assert manifest["design_risk_score"] >= 0.5

--- a/tests/test_id_allocator.py
+++ b/tests/test_id_allocator.py
@@ -1,0 +1,33 @@
+"""Tests for deterministic ID allocation in design documents."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from src.services.id_allocator import ensure_ids
+
+
+def _sample_design() -> dict:
+    return {
+        "app_name": "life-claims-portal",
+        "components": [
+            {"name": "login-ui", "tier": "tier-0", "exposure": "internet", "pii": True},
+            {"name": "claims-core", "tier": "tier-0", "exposure": "internal", "pii": True},
+        ],
+    }
+
+
+def test_ensure_ids_mints_app_and_component_ids() -> None:
+    design = _sample_design()
+    enriched = ensure_ids(design)
+    assert enriched["app_id"].startswith("APP-")
+    component_ids = [component["component_id"] for component in enriched["components"]]
+    assert component_ids == ["C-login", "C-claims"]
+
+
+def test_ensure_ids_is_deterministic() -> None:
+    design = _sample_design()
+    first = ensure_ids(design)
+    second = ensure_ids(deepcopy(design))
+    assert first == second
+    assert design.get("app_id") is None

--- a/tests/test_run_registry.py
+++ b/tests/test_run_registry.py
@@ -1,0 +1,48 @@
+"""Tests for the run registry service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services import run_registry
+
+
+def _prepare(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> run_registry.RunContext:
+    monkeypatch.setattr(run_registry, "ARTEFACTS_ROOT", tmp_path)
+    return run_registry.resolve_run("APP-1234")
+
+
+def test_resolve_run_creates_expected_structure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = _prepare(monkeypatch, tmp_path)
+    assert ctx.app_id == "APP-1234"
+    assert ctx.run_path.exists()
+    assert ctx.inputs_dir.exists()
+    assert ctx.outputs_dir.exists()
+    assert ctx.signed_outputs_dir.exists()
+
+
+def test_save_input_and_write_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = _prepare(monkeypatch, tmp_path)
+    raw_path = ctx.save_input("requirements-input.csv", b"feature,enabled\nfoo,true\n")
+    assert raw_path.read_text() == "feature,enabled\nfoo,true\n"
+
+    json_path = ctx.save_input("requirements.json", {"hello": "world"})
+    assert json.loads(json_path.read_text())["hello"] == "world"
+
+    output_doc = {"requirements": []}
+    output_path = ctx.write_output("requirements.json", output_doc)
+    assert json.loads(output_path.read_text()) == output_doc
+
+    with pytest.raises(ValueError):
+        ctx.write_output("unexpected.json", {})
+
+
+def test_reopen_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = _prepare(monkeypatch, tmp_path)
+    reopened = run_registry.reopen_run(ctx.app_id, ctx.run_id)
+    assert reopened.app_id == ctx.app_id
+    assert reopened.run_id == ctx.run_id
+    assert reopened.inputs_dir.exists()


### PR DESCRIPTION
## Summary
- introduce a run registry service that materialises artefact directories with canonical output slots
- add a unified artefact ingestion endpoint that stores inputs per run and begins the design processing flow
- ensure design submissions mint deterministic app/component identifiers and persist a design manifest

## Testing
- pytest tests/test_run_registry.py
- pytest tests/test_api_artefacts.py
- pytest tests/test_id_allocator.py

------
https://chatgpt.com/codex/tasks/task_e_68e66357ab408329928162bc966ce281